### PR TITLE
Update tests to verify extension can activate

### DIFF
--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as assert from 'assert';
 import { IHookCallbackContext } from 'mocha';
 import * as vscode from 'vscode';
 import { TestOutputChannel, TestUserInput } from 'vscode-azureextensiondev';
@@ -19,10 +20,23 @@ export function createTestActionContext(): IActionContext {
 suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
     this.timeout(1 * 60 * 1000);
 
-    await vscode.commands.executeCommand('staticWebApps.refresh'); // activate the extension before tests begin
+    const extension = vscode.extensions.getExtension('ms-azuretools.vscode-azurestaticwebapps');
+    if (!extension) {
+        assert.fail('Failed to find extension.');
+    } else {
+        await extension.activate();
+    }
+
     ext.outputChannel = new TestOutputChannel();
     ext.ui = testUserInput;
 
     // tslint:disable-next-line:strict-boolean-expressions
     longRunningTestsEnabled = !/^(false|0)?$/i.test(process.env.ENABLE_LONG_RUNNING_TESTS || '');
+});
+
+suite('suite1', () => {
+    test('test1', () => {
+        // suiteSetup only runs if a suite/test exists, so added a placeholder test here so we can at least verify the extension can activate
+        // once actual tests exist, we can remove this
+    });
 });


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azurestaticwebapps/pull/24#discussion_r421665547, the extension currently fails to activate if you don't use webpack. Turns out the tests weren't verifying extension activation at all. Now it will - as seen by the following error if I run tests locally without webpack:
```
  1) "before all" hook in "{root}"
spec.js:88
  0 passing (212ms)
base.js:349
  1 failing
base.js:362
  1) "before all" hook in "{root}":
     Error: Cannot find module './dist/extension.bundle'
Require stack:
- /Users/erijiz/Repos/vscode-azurestaticwebapps/main.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/loader.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-amd.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/bootstrap-fork.js
```

Doesn't really prevent the above mentioned problem since the CI build always runs webpack, but could theoretically find other issues in the future 🤷‍♂️