### PR TITLE
Validates Az Func ext is installed before attempting api/endpoint actions

### DIFF
--- a/src/commands/createNewApi.ts
+++ b/src/commands/createNewApi.ts
@@ -4,11 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
 import { noWorkspaceError } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../utils/localize';
+import { validateFuncExtInstalled } from './validateFuncExtInstalled';
 
-export async function createNewApi(): Promise<void> {
+export async function createNewApi(context: IActionContext): Promise<void> {
+    await validateFuncExtInstalled(context);
+
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length <= 0) {
         throw new Error(noWorkspaceError);
     }

--- a/src/commands/createNewEndpoint/createNewEndpoint.ts
+++ b/src/commands/createNewEndpoint/createNewEndpoint.ts
@@ -9,8 +9,11 @@ import * as vscode from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
 import { noWorkspaceError } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { validateFuncExtInstalled } from '../validateFuncExtInstalled';
 
-export async function createNewEndpoint(_context: IActionContext): Promise<void> {
+export async function createNewEndpoint(context: IActionContext): Promise<void> {
+    await validateFuncExtInstalled(context);
+
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length <= 0) {
         throw new Error(noWorkspaceError);
     }
@@ -31,7 +34,6 @@ export async function createNewEndpoint(_context: IActionContext): Promise<void>
     }
 
     newName = await ext.ui.showInputBox({ value: newName, prompt: 'Provide an endpoint name' });
-
     await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, 'HttpTrigger', newName, { authLevel: 'anonymous' });
 
 }

--- a/src/commands/validateFuncExtInstalled.ts
+++ b/src/commands/validateFuncExtInstalled.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { commands, extensions } from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
+import { localize } from '../utils/localize';
+
+export async function validateFuncExtInstalled(context: IActionContext): Promise<void> {
+    context.errorHandling.suppressDisplay = true;
+    context.telemetry.suppressIfSuccessful = true;
+
+    const azFuncExtId: string = 'ms-azuretools.vscode-azurefunctions';
+    if (extensions.getExtension(azFuncExtId) === undefined) {
+        const functionsRequired: string = localize('functionsRequired', 'You must have the "Azure Functions" extension installed to perform this operation.');
+        await ext.ui.showWarningMessage(functionsRequired, { title: localize('install', 'Install') });
+        const commandToRun: string = 'extension.open';
+        commands.executeCommand(commandToRun, azFuncExtId);
+        throw new Error(functionsRequired);
+    }
+}


### PR DESCRIPTION
Fixes #32 

![image](https://user-images.githubusercontent.com/5290572/81375113-a6caa480-90b5-11ea-9365-b9777c97d20b.png)

Basically just checks if the ext. is installed before prompting and directs them to the extension if they hit install.  Once we have the API, I'll update this to look for that.
