### PR TITLE
Fix load more in repo picks

### DIFF
--- a/src/github/GitHubBranchListStep.ts
+++ b/src/github/GitHubBranchListStep.ts
@@ -13,12 +13,14 @@ import { nonNullProp } from '../utils/nonNull';
 
 export class GitHubBranchListStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
+        let branchData: gitHubBranchData | undefined;
         const { owner, name } = await getRepoFullname(nonNullProp(context, 'repoHtmlUrl'));
         const placeHolder: string = localize('chooseBranch', 'Choose branch for repository "{0}/{1}"', owner, name);
-        let branchData: gitHubBranchData | undefined;
+
+        const requestOption: gitHubWebResource = await createGitHubRequestOptions(context, `${githubApiEndpoint}/repos/${owner}/${name}/branches`);
         const picksCache: ICachedQuickPicks<gitHubBranchData> = { picks: [] };
         do {
-            branchData = (await ext.ui.showQuickPick(this.getBranchPicks(context, picksCache), { placeHolder })).data;
+            branchData = (await ext.ui.showQuickPick(this.getBranchPicks(requestOption, picksCache), { placeHolder })).data;
         } while (!branchData);
 
         context.branchData = branchData;
@@ -28,9 +30,7 @@ export class GitHubBranchListStep extends AzureWizardPromptStep<IStaticWebAppWiz
         return !context.branchData;
     }
 
-    private async getBranchPicks(context: IStaticWebAppWizardContext, picksCache: ICachedQuickPicks<gitHubBranchData>): Promise<IAzureQuickPickItem<gitHubBranchData | undefined>[]> {
-        const { owner, name } = await getRepoFullname(nonNullProp(context, 'repoHtmlUrl'));
-        const requestOption: gitHubWebResource = await createGitHubRequestOptions(context, `${githubApiEndpoint}/repos/${owner}/${name}/branches`);
+    private async getBranchPicks(requestOption: gitHubWebResource, picksCache: ICachedQuickPicks<gitHubBranchData>): Promise<IAzureQuickPickItem<gitHubBranchData | undefined>[]> {
         return await getGitHubQuickPicksWithLoadMore<gitHubBranchData>(picksCache, requestOption, 'name');
     }
 }

--- a/src/github/GitHubRepoListStep.ts
+++ b/src/github/GitHubRepoListStep.ts
@@ -45,7 +45,7 @@ export class GitHubRepoListStep extends AzureWizardPromptStep<IStaticWebAppWizar
 
     private async getRepoPicks(requestOptions: gitHubWebResource, picksCache: ICachedQuickPicks<gitHubRepoData>): Promise<IAzureQuickPickItem<gitHubRepoData | undefined>[]> {
         const quickPickItems: IAzureQuickPickItem<gitHubRepoData | undefined>[] =
-            await getGitHubQuickPicksWithLoadMore<gitHubRepoData>(picksCache, requestOptions, 'name', 0.1); //CHANGE BACK
+            await getGitHubQuickPicksWithLoadMore<gitHubRepoData>(picksCache, requestOptions, 'name');
         quickPickItems.unshift({ label: localize(createNewRepo, '$(plus) Create a new GitHub repository...'), data: { name: createNewRepo, html_url: createNewRepo, url: createNewRepo } });
 
         return quickPickItems;


### PR DESCRIPTION
Note, loadMoreBranches is still busted.  That one isn't as trivial to fix because I build the url in `getBranchPicks` like so `${githubApiEndpoint}/repos/${owner}/${repo}/branches`.

I could create a new property on context, but that felt a little more complicated than I wanted for this PR