### PR TITLE
Check if user to get private repos

### DIFF
--- a/src/commands/createStaticWebApp/GitHubRepoListStep.ts
+++ b/src/commands/createStaticWebApp/GitHubRepoListStep.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from 'vscode-azureextensionui';
+import { githubApiEndpoint } from '../../constants';
 import { ext } from '../../extensionVariables';
-import { createGitHubRequestOptions, getGitHubQuickPicksWithLoadMore, gitHubRepoData, gitHubWebResource, ICachedQuickPicks } from '../../utils/gitHubUtils';
+import { createGitHubRequestOptions, getGitHubQuickPicksWithLoadMore, gitHubOrgData, gitHubRepoData, gitHubWebResource, ICachedQuickPicks } from '../../utils/gitHubUtils';
 import { localize } from '../../utils/localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { IStaticWebAppWizardContext } from './IStaticWebAppWizardContext';
@@ -18,7 +19,8 @@ export class GitHubRepoListStep extends AzureWizardPromptStep<IStaticWebAppWizar
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const placeHolder: string = localize('chooseRepo', 'Choose repository');
         let repoData: gitHubRepoData | undefined;
-        const requestOptions: gitHubWebResource = await createGitHubRequestOptions(context, nonNullProp(context, 'orgData').repos_url);
+        const orgData: gitHubOrgData = nonNullProp(context, 'orgData');
+        const requestOptions: gitHubWebResource = await createGitHubRequestOptions(context, orgData.type === 'User' ? `${githubApiEndpoint}/user/repos?type=owner` : orgData.repos_url);
         const picksCache: ICachedQuickPicks<gitHubRepoData> = { picks: [] };
 
         do {

--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -15,7 +15,8 @@ import { IStaticWebAppWizardContext } from '../commands/createStaticWebApp/IStat
 import { githubApiEndpoint } from '../constants';
 import { requestUtils } from './requestUtils';
 
-export type gitHubOrgData = { login: string; repos_url: string };
+// tslint:disable-next-line:no-reserved-keywords
+export type gitHubOrgData = { login: string; repos_url: string; type: 'User' | 'Organization' };
 export type gitHubRepoData = { name: string; url: string; html_url: string; clone_url?: string; default_branch?: string };
 export type gitHubBranchData = { name: string };
 export type gitHubLink = { prev?: string; next?: string; last?: string; first?: string };


### PR DESCRIPTION
When retrieving user repos, we aren't getting private repos.

That's because the repo_url defaults to this endpoint
https://developer.github.com/v3/repos/#list-repositories-for-a-user

But for a user, we need to build the url to look like this:
https://developer.github.com/v3/repos/#list-repositories-for-the-authenticated-user

For an org, the repo_url is automatically gets all repos, including private
https://developer.github.com/v3/repos/#list-organization-repositories