### PR TITLE
Add command to view GitHub repo/branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "onCommand:staticWebApps.appSettings.edit",
         "onCommand:staticWebApps.appSettings.rename",
         "onCommand:staticWebApps.appSettings.delete",
-        "onCommand:staticWebApps.viewGitHubRepo",
+        "onCommand:staticWebApps.openGitHubRepo",
         "onView:staticWebApps"
     ],
     "main": "./main.js",
@@ -149,8 +149,8 @@
                 }
             },
             {
-                "command": "staticWebApps.viewGitHubRepo",
-                "title": "%staticWebApps.viewGitHubRepo%",
+                "command": "staticWebApps.openGitHubRepo",
+                "title": "%staticWebApps.openGitHubRepo%",
                 "category": "Azure Static Web Apps"
             }
         ],
@@ -221,8 +221,8 @@
                     "group": "1@1"
                 },
                 {
-                    "command": "staticWebApps.viewGitHubRepo",
-                    "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment)$/",
+                    "command": "staticWebApps.openGitHubRepo",
+                    "when": "view == staticWebApps && viewItem == azureStaticEnvironment",
                     "group": "1@2"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "onCommand:staticWebApps.appSettings.edit",
         "onCommand:staticWebApps.appSettings.rename",
         "onCommand:staticWebApps.appSettings.delete",
+        "onCommand:staticWebApps.viewGitHubRepo",
         "onView:staticWebApps"
     ],
     "main": "./main.js",
@@ -146,6 +147,11 @@
                     "light": "resources/light/Visible.svg",
                     "dark": "resources/dark/Visible.svg"
                 }
+            },
+            {
+                "command": "staticWebApps.viewGitHubRepo",
+                "title": "%staticWebApps.viewGitHubRepo%",
+                "category": "Azure Static Web Apps"
             }
         ],
         "viewsContainers": {
@@ -213,6 +219,11 @@
                     "command": "staticWebApps.browse",
                     "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment)$/",
                     "group": "1@1"
+                },
+                {
+                    "command": "staticWebApps.viewGitHubRepo",
+                    "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment)$/",
+                    "group": "1@2"
                 },
                 {
                     "command": "staticWebApps.showActions",

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,5 +19,6 @@
     "staticWebApps.appSettings.edit": "Edit Setting...",
     "staticWebApps.appSettings.rename": "Rename Setting...",
     "staticWebApps.appSettings.delete": "Delete Setting...",
-    "staticWebApps.toggleAppSettingVisibility": "Toggle App Setting Visibility."
+    "staticWebApps.toggleAppSettingVisibility": "Toggle App Setting Visibility.",
+    "staticWebApps.viewGitHubRepo": "View GitHub Repo"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -20,5 +20,5 @@
     "staticWebApps.appSettings.rename": "Rename Setting...",
     "staticWebApps.appSettings.delete": "Delete Setting...",
     "staticWebApps.toggleAppSettingVisibility": "Toggle App Setting Visibility.",
-    "staticWebApps.viewGitHubRepo": "View GitHub Repo"
+    "staticWebApps.openGitHubRepo": "Open Repo in GitHub"
 }

--- a/src/commands/openGitHubRepo.ts
+++ b/src/commands/openGitHubRepo.ts
@@ -8,7 +8,7 @@ import { ext } from '../extensionVariables';
 import { EnvironmentTreeItem } from '../tree/EnvironmentTreeItem';
 import { openUrl } from '../utils/openUrl';
 
-export async function viewGitHubRepo(context: IActionContext, node?: EnvironmentTreeItem): Promise<void> {
+export async function openGitHubRepo(context: IActionContext, node?: EnvironmentTreeItem): Promise<void> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<EnvironmentTreeItem>(EnvironmentTreeItem.contextValue, context);
     }

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -17,9 +17,9 @@ import { createHttpFunction } from './createHttpFunction';
 import { createStaticWebApp } from './createStaticWebApp/createStaticWebApp';
 import { deleteNode } from './deleteNode';
 import { deleteStaticWebApp } from './deleteStaticWebApp';
+import { openGitHubRepo } from './openGitHubRepo';
 import { openInPortal } from './openInPortal';
 import { showActions } from './showActions';
-import { viewGitHubRepo } from './viewGitHubRepo';
 import { viewProperties } from './viewProperties';
 
 export function registerCommands(): void {
@@ -33,7 +33,7 @@ export function registerCommands(): void {
     registerCommand('staticWebApps.createHttpFunction', createHttpFunction);
     registerCommand('staticWebApps.browse', browse);
     registerCommand('staticWebApps.showActions', showActions);
-    registerCommand('staticWebApps.viewGitHubRepo', viewGitHubRepo);
+    registerCommand('staticWebApps.openGitHubRepo', openGitHubRepo);
     registerCommand('staticWebApps.appSettings.add', async (context: IActionContext, node?: AzExtParentTreeItem) => await createChildNode(context, AppSettingsTreeItem.contextValue, node));
     registerCommand('staticWebApps.appSettings.delete', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, AppSettingTreeItem.contextValue, node));
     registerCommand('staticWebApps.appSettings.edit', editAppSetting);

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -19,6 +19,7 @@ import { deleteNode } from './deleteNode';
 import { deleteStaticWebApp } from './deleteStaticWebApp';
 import { openInPortal } from './openInPortal';
 import { showActions } from './showActions';
+import { viewGitHubRepo } from './viewGitHubRepo';
 import { viewProperties } from './viewProperties';
 
 export function registerCommands(): void {
@@ -32,6 +33,7 @@ export function registerCommands(): void {
     registerCommand('staticWebApps.createHttpFunction', createHttpFunction);
     registerCommand('staticWebApps.browse', browse);
     registerCommand('staticWebApps.showActions', showActions);
+    registerCommand('staticWebApps.viewGitHubRepo', viewGitHubRepo);
     registerCommand('staticWebApps.appSettings.add', async (context: IActionContext, node?: AzExtParentTreeItem) => await createChildNode(context, AppSettingsTreeItem.contextValue, node));
     registerCommand('staticWebApps.appSettings.delete', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, AppSettingTreeItem.contextValue, node));
     registerCommand('staticWebApps.appSettings.edit', editAppSetting);

--- a/src/commands/viewGitHubRepo.ts
+++ b/src/commands/viewGitHubRepo.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
+import { EnvironmentTreeItem } from '../tree/EnvironmentTreeItem';
+import { openUrl } from '../utils/openUrl';
+
+export async function viewGitHubRepo(context: IActionContext, node?: EnvironmentTreeItem): Promise<void> {
+    if (!node) {
+        node = await ext.tree.showTreeItemPicker<EnvironmentTreeItem>(EnvironmentTreeItem.contextValue, context);
+    }
+
+    await openUrl(`${node.parent.data.properties.repositoryUrl}/tree/${node.data.properties.sourceBranch}`);
+}

--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -28,6 +28,8 @@ export type StaticEnvironment = {
 export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureResourceTreeItem {
     public static contextValue: string = 'azureStaticEnvironment';
     public readonly contextValue: string = EnvironmentTreeItem.contextValue;
+
+    public parent: StaticWebAppTreeItem;
     public appSettingsTreeItem: AppSettingsTreeItem;
     public functionsTreeItem: FunctionsTreeItem;
     public readonly data: StaticEnvironment;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/95

Rather than just taking the user to the attached repo, I added the branch information so it'd open the site with that specific branch up.  I think that's actually a little more useful (especially since the command exists on each environment) 