### PR TITLE
Conform our default value to portal

### DIFF
--- a/src/commands/createStaticWebApp/AppLocationStep.ts
+++ b/src/commands/createStaticWebApp/AppLocationStep.ts
@@ -11,10 +11,10 @@ import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
 export class AppLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
-        const defaultLocation: string = 'app';
+        const defaultLocation: string = '/';
         wizardContext.appLocation = (await ext.ui.showInputBox({
             value: defaultLocation,
-            prompt: localize('appLocation', "Enter the location of your application code")
+            prompt: localize('appLocation', "Enter the location of your application code. For example, '/' represents the root of your app, while '/app' represents a directory called 'app'.")
         })).trim();
         addLocationTelemetry(wizardContext, 'appLocation', defaultLocation);
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/91

The default value is now '/', signifying the root.  I updated the message to include the tool tip the portal provides for clarity, since I think it's not super intuitive anyway.

![image](https://user-images.githubusercontent.com/5290572/83915269-c215e780-a727-11ea-80d4-f3c5afe5796e.png)
 
![image](https://user-images.githubusercontent.com/5290572/83915325-d1953080-a727-11ea-9775-c64132ae0e78.png)
