### PR TITLE
Remove # from label

### DIFF
--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -50,7 +50,7 @@ export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureRe
     }
 
     public get label(): string {
-        return this.data.properties.buildId === 'default' ? productionEnvironmentName : `#${this.name} - ${this.data.properties.pullRequestTitle}`;
+        return this.data.properties.buildId === 'default' ? productionEnvironmentName : `${this.name} - ${this.data.properties.pullRequestTitle}`;
     }
 
     public get description(): string | undefined {


### PR DESCRIPTION
Fixes #120 

So when parsing a URI, "#" are recognized as a special symbol that indicates a "fragment".  So that ends up cutting the path short at the subscription id number.  I tried to escape it, but I don't think it was being recognized as just a plain text character.  I might be able to use the unicode, but honestly I feel like the easiest solution is to just remove it.  It doesn't really matter if we have the # in there or not, imo.