### PR TITLE
Add git clone 👨🏼‍🤝‍👨🏼 to static web app

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "onCommand:staticWebApps.createHttpFunction",
         "onCommand:staticWebApps.browse",
         "onCommand:staticWebApps.showActions",
+        "onCommand:staticWebApps.cloneRepo",
         "onCommand:staticWebApps.appSettings.add",
         "onCommand:staticWebApps.appSettings.upload",
         "onCommand:staticWebApps.appSettings.edit",
@@ -112,6 +113,11 @@
             {
                 "command": "staticWebApps.showActions",
                 "title": "%staticWebApps.showActions%",
+                "category": "Azure Static Web Apps"
+            },
+            {
+                "command": "staticWebApps.cloneRepo",
+                "title": "%staticWebApps.cloneRepo%",
                 "category": "Azure Static Web Apps"
             },
             {
@@ -229,6 +235,11 @@
                     "command": "staticWebApps.showActions",
                     "when": "view == staticWebApps && viewItem == azureStaticWebApp",
                     "group": "1@2"
+                },
+                {
+                    "command": "staticWebApps.cloneRepo",
+                    "when": "view == staticWebApps && viewItem == azureStaticWebApp",
+                    "group": "1@3"
                 },
                 {
                     "command": "staticWebApps.viewProperties",

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,6 +14,7 @@
     "staticWebApps.createHttpFunction": "Create HTTP Function...",
     "staticWebApps.browse": "Browse Site",
     "staticWebApps.showActions": "Show Actions",
+    "staticWebApps.cloneRepo": "Clone Repo...",
     "staticWebApps.appSettings.add": "Add New Setting...",
     "staticWebApps.appSettings.upload": "Upload Local Settings...",
     "staticWebApps.appSettings.edit": "Edit Setting...",

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -9,7 +9,7 @@ import { ext } from '../../extensionVariables';
 import { StaticWebAppTreeItem } from '../../tree/StaticWebAppTreeItem';
 import { SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
 import { localize } from '../../utils/localize';
-import { showActions } from '../showActions';
+import { showActions } from '../github/showActions';
 
 export async function createStaticWebApp(context: IActionContext, node?: SubscriptionTreeItem): Promise<void> {
     if (!node) {

--- a/src/commands/github/cloneRepo.ts
+++ b/src/commands/github/cloneRepo.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { commands } from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../../extensionVariables';
+import { StaticWebAppTreeItem } from '../../tree/StaticWebAppTreeItem';
+
+export async function cloneRepo(context: IActionContext, node?: StaticWebAppTreeItem): Promise<void> {
+    if (!node) {
+        node = await ext.tree.showTreeItemPicker<StaticWebAppTreeItem>(StaticWebAppTreeItem.contextValue, context);
+    }
+
+    await commands.executeCommand('git.clone', node.data.properties.repositoryUrl);
+}

--- a/src/commands/github/openGitHubRepo.ts
+++ b/src/commands/github/openGitHubRepo.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
-import { EnvironmentTreeItem } from '../tree/EnvironmentTreeItem';
-import { openUrl } from '../utils/openUrl';
+import { ext } from '../../extensionVariables';
+import { EnvironmentTreeItem } from '../../tree/EnvironmentTreeItem';
+import { openUrl } from '../../utils/openUrl';
 
 export async function openGitHubRepo(context: IActionContext, node?: EnvironmentTreeItem): Promise<void> {
     if (!node) {

--- a/src/commands/github/showActions.ts
+++ b/src/commands/github/showActions.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as ui from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
-import { EnvironmentTreeItem } from '../tree/EnvironmentTreeItem';
-import { StaticWebAppTreeItem } from '../tree/StaticWebAppTreeItem';
-import { openUrl } from '../utils/openUrl';
+import { ext } from '../../extensionVariables';
+import { EnvironmentTreeItem } from '../../tree/EnvironmentTreeItem';
+import { StaticWebAppTreeItem } from '../../tree/StaticWebAppTreeItem';
+import { openUrl } from '../../utils/openUrl';
 
 export async function showActions(context: ui.IActionContext, node?: StaticWebAppTreeItem | EnvironmentTreeItem): Promise<void> {
     if (node instanceof EnvironmentTreeItem) {

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -16,9 +16,10 @@ import { createHttpFunction } from './createHttpFunction';
 import { createStaticWebApp } from './createStaticWebApp/createStaticWebApp';
 import { deleteNode } from './deleteNode';
 import { deleteStaticWebApp } from './deleteStaticWebApp';
-import { openGitHubRepo } from './openGitHubRepo';
+import { cloneRepo } from './github/cloneRepo';
+import { openGitHubRepo } from './github/openGitHubRepo';
+import { showActions } from './github/showActions';
 import { openInPortal } from './openInPortal';
-import { showActions } from './showActions';
 import { viewProperties } from './viewProperties';
 
 export function registerCommands(): void {
@@ -32,6 +33,7 @@ export function registerCommands(): void {
     registerCommand('staticWebApps.createHttpFunction', createHttpFunction);
     registerCommand('staticWebApps.browse', browse);
     registerCommand('staticWebApps.showActions', showActions);
+    registerCommand('staticWebApps.cloneRepo', cloneRepo);
     registerCommand('staticWebApps.openGitHubRepo', openGitHubRepo);
     registerCommand('staticWebApps.appSettings.add', async (context: IActionContext, node?: AzExtParentTreeItem) => await createChildNode(context, AppSettingsTreeItem.contextValue, node));
     registerCommand('staticWebApps.appSettings.delete', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, AppSettingTreeItem.contextValue, node));


### PR DESCRIPTION
Fixes #33 

There were enough GitHub specific actions that I think it's worth throwing them in their own folder.  None of those files were edited besides their imports.

I'm reconsidering where we have this on the context menu...  Today it looks like this

![image](https://user-images.githubusercontent.com/5290572/85638104-de77b680-b639-11ea-8524-a142232d9f91.png)

![image](https://user-images.githubusercontent.com/5290572/85638116-e7688800-b639-11ea-89c8-a9bb91b1eeb9.png)

I made the choice to have Open Repo in Github exist on the Environment (rather than the Static Web App) because I can open it to the _specific_ branch that they have configured to the app.

Clone and Actions don't have that level of granularity, the target is the repo itself.  But I feel like there's a weird split of where the context action menu items are.  Thoughts?
