### PR TITLE
add SuppressCreatePick ⛏ to treePickers 🌲⛏

### DIFF
--- a/src/commands/appSettings/editAppSetting.ts
+++ b/src/commands/appSettings/editAppSetting.ts
@@ -9,7 +9,7 @@ import { ext } from '../../extensionVariables';
 
 export async function editAppSetting(context: IActionContext, node?: AppSettingTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<AppSettingTreeItem>(AppSettingTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<AppSettingTreeItem>(AppSettingTreeItem.contextValue, { ...context, suppressCreatePick: true });
     }
 
     await node.edit(context);

--- a/src/commands/appSettings/renameAppSetting.ts
+++ b/src/commands/appSettings/renameAppSetting.ts
@@ -9,7 +9,7 @@ import { ext } from '../../extensionVariables';
 
 export async function renameAppSetting(context: IActionContext, node?: AppSettingTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<AppSettingTreeItem>(AppSettingTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<AppSettingTreeItem>(AppSettingTreeItem.contextValue, { ...context, suppressCreatePick: true });
     }
 
     await node.rename(context);

--- a/src/commands/appSettings/uploadAppSettings.ts
+++ b/src/commands/appSettings/uploadAppSettings.ts
@@ -24,7 +24,7 @@ interface ILocalSettingsJson {
 export async function uploadAppSettings(context: IActionContext, node?: AppSettingsTreeItem): Promise<void> {
     const localSettingsPath: string = await getLocalSettingsFile();
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<AppSettingsTreeItem>(AppSettingsTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<AppSettingsTreeItem>(AppSettingsTreeItem.contextValue, { ...context, suppressCreatePick: true });
     }
 
     await node.runWithTemporaryDescription(localize('uploading', 'Uploading...'), async () => {

--- a/src/commands/deleteStaticWebApp.ts
+++ b/src/commands/deleteStaticWebApp.ts
@@ -10,7 +10,7 @@ import { localize } from '../utils/localize';
 
 export async function deleteStaticWebApp(context: IActionContext, node?: StaticWebAppTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<StaticWebAppTreeItem>(StaticWebAppTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<StaticWebAppTreeItem>(StaticWebAppTreeItem.contextValue, { ...context, suppressCreatePick: true });
     }
 
     const confirmMessage: string = localize('deleteConfirmation', 'Are you sure you want to delete "{0}"?', node.name);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/110

I thought about fixing this by just calling deleteNode and putting the confirmation in StaticTreeItem.deleteTreeItemImpl, but then you have the deleting spinner on the treeItem before the confirmation box.  I feel like that this is a manageable solution for now.

I might make a new function that calls deleteNode, but is called deleteNodeWithConfirm or something like that to be used for Static Web Apps and eventually Environments.

Also suppressing edit, rename, and upload made sense to me.