### PR TITLE
Save defaults after creation of first SWA app

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,6 +321,21 @@
                         "type": "boolean",
                         "description": "%staticWebApps.enableOutputTimestamps%",
                         "default": true
+                    },
+                    "staticWebApps.appSubpath": {
+                        "scope": "resource",
+                        "type": "string",
+                        "description": "%staticWebApps.appSubpath%"
+                    },
+                    "staticWebApps.apiSubpath": {
+                        "scope": "resource",
+                        "type": "string",
+                        "description": "%staticWebApps.apiSubpath%"
+                    },
+                    "staticWebApps.appArtifactSubpath": {
+                        "scope": "resource",
+                        "type": "string",
+                        "description": "%staticWebApps.appArtifactSubpath%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -21,5 +21,8 @@
     "staticWebApps.appSettings.rename": "Rename Setting...",
     "staticWebApps.appSettings.delete": "Delete Setting...",
     "staticWebApps.toggleAppSettingVisibility": "Toggle App Setting Visibility.",
-    "staticWebApps.openGitHubRepo": "Open Repo in GitHub"
+    "staticWebApps.openGitHubRepo": "Open Repo in GitHub",
+    "staticWebApps.appSubpath": "The default value for the location of the application code prompt",
+    "staticWebApps.apiSubpath": "The default value for the location of your Azure Functions code",
+    "staticWebApps.appArtifactSubpath": "The default value for the location of your build output relative to your application code location"
 }

--- a/src/commands/createStaticWebApp/ApiLocationStep.ts
+++ b/src/commands/createStaticWebApp/ApiLocationStep.ts
@@ -4,16 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
-import { defaultApiName } from "../../constants";
+import { apiSubpathSetting, defaultApiName } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
+import { getWorkspaceSetting } from "../../utils/settingsUtils";
 import { addLocationTelemetry } from "./addLocationTelemetry";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
 export class ApiLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
         wizardContext.apiLocation = (await ext.ui.showInputBox({
-            value: defaultApiName,
+            value: getWorkspaceSetting(apiSubpathSetting, wizardContext.fsPath) || defaultApiName,
             prompt: localize('apiLocation', "Enter the location of your Azure Functions code (Leave blank for no Azure Functions code)"),
         })).trim();
         addLocationTelemetry(wizardContext, 'apiLocation', defaultApiName);

--- a/src/commands/createStaticWebApp/AppArtifactLocationStep.ts
+++ b/src/commands/createStaticWebApp/AppArtifactLocationStep.ts
@@ -4,8 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
+import { appArtifactSubpathSetting } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
+import { getWorkspaceSetting } from "../../utils/settingsUtils";
 import { addLocationTelemetry } from "./addLocationTelemetry";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
@@ -13,7 +15,7 @@ export class AppArtifactLocationStep extends AzureWizardPromptStep<IStaticWebApp
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
         const defaultLocation: string = 'build';
         wizardContext.appArtifactLocation = (await ext.ui.showInputBox({
-            value: defaultLocation,
+            value: getWorkspaceSetting(appArtifactSubpathSetting, wizardContext.fsPath) || defaultLocation,
             prompt: localize('publishLocation', "Enter the path of your build output relative to your app's location. For example, setting a value of 'build' when your app location is set to 'app' will cause the content at 'app/build' to be served.")
         })).trim();
         addLocationTelemetry(wizardContext, 'appArtifactLocation', defaultLocation);

--- a/src/commands/createStaticWebApp/AppLocationStep.ts
+++ b/src/commands/createStaticWebApp/AppLocationStep.ts
@@ -4,8 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
+import { appSubpathSetting } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
+import { getWorkspaceSetting } from "../../utils/settingsUtils";
 import { addLocationTelemetry } from "./addLocationTelemetry";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
@@ -13,7 +15,7 @@ export class AppLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardCo
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
         const defaultLocation: string = '/';
         wizardContext.appLocation = (await ext.ui.showInputBox({
-            value: defaultLocation,
+            value: getWorkspaceSetting(appSubpathSetting, wizardContext.fsPath) || defaultLocation,
             prompt: localize('appLocation', "Enter the location of your application code. For example, '/' represents the root of your app, while '/app' represents a directory called 'app'.")
         })).trim();
         addLocationTelemetry(wizardContext, 'appLocation', defaultLocation);

--- a/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
+++ b/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
@@ -13,6 +13,7 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext 
     repoData?: gitHubRepoData;
     branchData?: gitHubBranchData;
     repoHtmlUrl?: string;
+    fsPath?: string;
 
     newStaticWebAppName?: string;
     newRepoName?: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,7 @@ export const githubApiEndpoint: string = 'https://api.github.com';
 export const localSettingsFileName: string = 'local.settings.json';
 export const defaultApiName: string = 'api';
 export const productionEnvironmentName: string = 'Production';
+
+export const appSubpathSetting: string = 'appSubpath';
+export const apiSubpathSetting: string = 'apiSubpath';
+export const appArtifactSubpathSetting: string = 'appArtifactSubpath';

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -73,7 +73,8 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
         wizardContext.accessToken = await getGitHubAccessToken();
         wizardContext.repoHtmlUrl = await tryGetRemote(wizardContext);
-        wizardContext.telemetry.properties.gotRemote = String(!!wizardContext.repoHtmlUrl);
+        const gotRemote: boolean = !!wizardContext.repoHtmlUrl;
+        wizardContext.telemetry.properties.gotRemote = String(gotRemote);
 
         wizardContext.fsPath = getSingleRootFsPath();
 
@@ -84,7 +85,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         await wizard.execute();
         context.showCreatingTreeItem(newStaticWebAppName);
 
-        if (wizardContext.fsPath) {
+        if (wizardContext.fsPath && gotRemote) {
             await updateWorkspaceSetting(appSubpathSetting, wizardContext.appLocation, wizardContext.fsPath);
             await updateWorkspaceSetting(apiSubpathSetting, wizardContext.apiLocation, wizardContext.fsPath);
             await updateWorkspaceSetting(appArtifactSubpathSetting, wizardContext.appArtifactLocation, wizardContext.fsPath);

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ConfigurationTarget, Uri, workspace, WorkspaceConfiguration } from "vscode";
+import { ext } from "../extensionVariables";
+
+/**
+ * Uses ext.prefix 'staticWebApps' unless otherwise specified
+ */
+export async function updateGlobalSetting<T = string>(section: string, value: T, prefix: string = ext.prefix): Promise<void> {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
+    await projectConfiguration.update(section, value, ConfigurationTarget.Global);
+}
+
+/**
+ * Uses ext.prefix 'staticWebApps' unless otherwise specified
+ */
+export async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string, prefix: string = ext.prefix): Promise<void> {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, Uri.file(fsPath));
+    await projectConfiguration.update(section, value);
+}
+
+/**
+ * Uses ext.prefix 'staticWebApps' unless otherwise specified
+ */
+export function getGlobalSetting<T>(key: string, prefix: string = ext.prefix): T | undefined {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
+    const result: { globalValue?: T } | undefined = projectConfiguration.inspect<T>(key);
+    return result && result.globalValue;
+}
+
+/**
+ * Uses ext.prefix 'staticWebApps' unless otherwise specified
+ */
+export function getWorkspaceSetting<T>(key: string, fsPath?: string, prefix: string = ext.prefix): T | undefined {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, fsPath ? Uri.file(fsPath) : undefined);
+    return projectConfiguration.get<T>(key);
+}
+
+/**
+ * Searches through all open folders and gets the current workspace setting (as long as there are no conflicts)
+ * Uses ext.prefix 'staticWebApps' unless otherwise specified
+ */
+export function getWorkspaceSettingFromAnyFolder(key: string, prefix: string = ext.prefix): string | undefined {
+    if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+        let result: string | undefined;
+        for (const folder of workspace.workspaceFolders) {
+            const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, folder.uri);
+            const folderResult: string | undefined = projectConfiguration.get<string>(key);
+            if (!result) {
+                result = folderResult;
+            } else if (folderResult && result !== folderResult) {
+                return undefined;
+            }
+        }
+        return result;
+    } else {
+        return getGlobalSetting(key, prefix);
+    }
+}

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -3,16 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ConfigurationTarget, Uri, workspace, WorkspaceConfiguration } from "vscode";
+import { Uri, workspace, WorkspaceConfiguration } from "vscode";
 import { ext } from "../extensionVariables";
-
-/**
- * Uses ext.prefix 'staticWebApps' unless otherwise specified
- */
-export async function updateGlobalSetting<T = string>(section: string, value: T, prefix: string = ext.prefix): Promise<void> {
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
-    await projectConfiguration.update(section, value, ConfigurationTarget.Global);
-}
 
 /**
  * Uses ext.prefix 'staticWebApps' unless otherwise specified
@@ -25,38 +17,7 @@ export async function updateWorkspaceSetting<T = string>(section: string, value:
 /**
  * Uses ext.prefix 'staticWebApps' unless otherwise specified
  */
-export function getGlobalSetting<T>(key: string, prefix: string = ext.prefix): T | undefined {
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
-    const result: { globalValue?: T } | undefined = projectConfiguration.inspect<T>(key);
-    return result && result.globalValue;
-}
-
-/**
- * Uses ext.prefix 'staticWebApps' unless otherwise specified
- */
 export function getWorkspaceSetting<T>(key: string, fsPath?: string, prefix: string = ext.prefix): T | undefined {
     const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, fsPath ? Uri.file(fsPath) : undefined);
     return projectConfiguration.get<T>(key);
-}
-
-/**
- * Searches through all open folders and gets the current workspace setting (as long as there are no conflicts)
- * Uses ext.prefix 'staticWebApps' unless otherwise specified
- */
-export function getWorkspaceSettingFromAnyFolder(key: string, prefix: string = ext.prefix): string | undefined {
-    if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-        let result: string | undefined;
-        for (const folder of workspace.workspaceFolders) {
-            const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, folder.uri);
-            const folderResult: string | undefined = projectConfiguration.get<string>(key);
-            if (!result) {
-                result = folderResult;
-            } else if (folderResult && result !== folderResult) {
-                return undefined;
-            }
-        }
-        return result;
-    } else {
-        return getGlobalSetting(key, prefix);
-    }
 }

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { workspace } from "vscode";
+
+// tslint:disable-next-line:export-name
+export function getSingleRootFsPath(): string | undefined {
+    // if this is no workspace or a multi-root workspace, return undefined
+    return workspace.workspaceFolders && workspace.workspaceFolders.length === 1 ? workspace.workspaceFolders[0].uri.fsPath : undefined;
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/36

Right now, the setting is just being used to set the default value when the prompts come up because I don't want to block users in any way.  But I figured when we have the concept of a basic create, we can auto-populate the value with these settings.

I figured that I should update the setting whenever the user creates the SWA.  Even if they use the default values, I think it makes sense to save it for them to expose the settings.

I think the `apiSubpath` setting should also be set in the case when we create an "api" folder for the user, but that'll be a separate PR.