### PR TITLE
Browse 👁‍🗨 selects an environment rather than app

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
                 },
                 {
                     "command": "staticWebApps.browse",
-                    "when": "view == staticWebApps && viewItem == azureStaticEnvironment",
+                    "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment)$/",
                     "group": "1@1"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
                 },
                 {
                     "command": "staticWebApps.browse",
-                    "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment)$/",
+                    "when": "view == staticWebApps && viewItem == azureStaticEnvironment",
                     "group": "1@1"
                 },
                 {

--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -5,11 +5,11 @@
 
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
-import { StaticWebAppTreeItem } from "../tree/StaticWebAppTreeItem";
+import { EnvironmentTreeItem } from '../tree/EnvironmentTreeItem';
 
-export async function browse(context: IActionContext, node?: StaticWebAppTreeItem): Promise<void> {
+export async function browse(context: IActionContext, node?: EnvironmentTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<StaticWebAppTreeItem>(StaticWebAppTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<EnvironmentTreeItem>(EnvironmentTreeItem.contextValue, context);
     }
 
     await node.browse();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/73

I think the original issue wanted the command names to include "Environment" in them, but I don't think most of the commands would make sense if renamed that way.

I made browse exclusive to environments because I'm trying to really separate the SWA from the environment. 

As for other commands that accept multiple tree items: openInPortal, viewProperties, refresh, etc. the command palette is looking for Static Web Apps because that's what made sense to me (and is the current behavior of other extensions.)