### PR TITLE
Add delete environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "activationEvents": [
         "onCommand:staticWebApps.createStaticWebApp",
         "onCommand:staticWebApps.deleteStaticWebApp",
+        "onCommand:staticWebApps.deleteEnvironment",
         "onCommand:staticWebApps.loadMore",
         "onCommand:staticWebApps.openInPortal",
         "onCommand:staticWebApps.refresh",
@@ -64,6 +65,11 @@
             {
                 "command": "staticWebApps.deleteStaticWebApp",
                 "title": "%staticWebApps.deleteStaticWebApp%",
+                "category": "Azure Static Web Apps"
+            },
+            {
+                "command": "staticWebApps.deleteEnvironment",
+                "title": "%staticWebApps.deleteEnvironment%",
                 "category": "Azure Static Web Apps"
             },
             {
@@ -229,11 +235,6 @@
                     "group": "9@2"
                 },
                 {
-                    "command": "staticWebApps.deleteStaticWebApp",
-                    "when": "view == staticWebApps && viewItem == azureStaticWebApp",
-                    "group": "3@1"
-                },
-                {
                     "command": "staticWebApps.browse",
                     "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment)$/",
                     "group": "1@1"
@@ -252,6 +253,16 @@
                     "command": "staticWebApps.cloneRepo",
                     "when": "view == staticWebApps && viewItem == azureStaticWebApp",
                     "group": "1@2"
+                },
+                {
+                    "command": "staticWebApps.deleteStaticWebApp",
+                    "when": "view == staticWebApps && viewItem == azureStaticWebApp",
+                    "group": "3@1"
+                },
+                {
+                    "command": "staticWebApps.deleteEnvironment",
+                    "when": "view == staticWebApps && viewItem == azureStaticEnvironment",
+                    "group": "3@1"
                 },
                 {
                     "command": "staticWebApps.viewProperties",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,7 @@
 {
     "staticWebApps.createStaticWebApp": "Create Static Web App...",
     "staticWebApps.deleteStaticWebApp": "Delete...",
+    "staticWebApps.deletedeleteEnvironment": "Delete Environment...",
     "staticWebApps.description": "An Azure Static Web Apps (Preview) extension for Visual Studio Code.",
     "staticWebApps.enableOutputTimestamps": "Prepends each line displayed in the output channel with a timestamp.",
     "staticWebApps.loadMore": "Load More",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,7 @@
 {
     "staticWebApps.createStaticWebApp": "Create Static Web App...",
     "staticWebApps.deleteStaticWebApp": "Delete...",
-    "staticWebApps.deletedeleteEnvironment": "Delete Environment...",
+    "staticWebApps.deleteEnvironment": "Delete Environment...",
     "staticWebApps.description": "An Azure Static Web Apps (Preview) extension for Visual Studio Code.",
     "staticWebApps.enableOutputTimestamps": "Prepends each line displayed in the output channel with a timestamp.",
     "staticWebApps.loadMore": "Load More",

--- a/src/commands/deleteEnvironment.ts
+++ b/src/commands/deleteEnvironment.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
+import { EnvironmentTreeItem } from '../tree/EnvironmentTreeItem';
+import { localize } from '../utils/localize';
+
+export async function deleteEnvironment(context: IActionContext, node?: EnvironmentTreeItem): Promise<void> {
+    if (!node) {
+        node = await ext.tree.showTreeItemPicker<EnvironmentTreeItem>(EnvironmentTreeItem.contextValue, { ...context, suppressCreatePick: true });
+    }
+
+    if (node.isProduction) {
+        throw new Error(localize('cantDeletePro', 'Cannot delete the production environment directly. Delete the static web app.'));
+    }
+
+    const confirmMessage: string = localize('deleteConfirmation', 'Are you sure you want to delete "{0}"?', node.label);
+    await ext.ui.showWarningMessage(confirmMessage, { modal: true }, DialogResponses.deleteResponse);
+    await node.deleteTreeItem(context);
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -14,6 +14,7 @@ import { browse } from './browse';
 import { createChildNode } from './createChildNode';
 import { createHttpFunction } from './createHttpFunction';
 import { createStaticWebApp } from './createStaticWebApp/createStaticWebApp';
+import { deleteEnvironment } from './deleteEnvironment';
 import { deleteNode } from './deleteNode';
 import { deleteStaticWebApp } from './deleteStaticWebApp';
 import { cancelAction, rerunAction } from './github/actionCommands';
@@ -26,6 +27,7 @@ import { viewProperties } from './viewProperties';
 export function registerCommands(): void {
     registerCommand('staticWebApps.createStaticWebApp', createStaticWebApp);
     registerCommand('staticWebApps.deleteStaticWebApp', deleteStaticWebApp);
+    registerCommand('staticWebApps.deleteEnvironment', deleteEnvironment);
     registerCommand('staticWebApps.loadMore', async (context: IActionContext, node: AzureTreeItem) => await ext.tree.loadMore(node, context));
     registerCommand('staticWebApps.openInPortal', openInPortal);
     registerCommand('staticWebApps.refresh', async (_context: IActionContext, node?: AzureTreeItem) => await ext.tree.refresh(node));

--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -3,13 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ProgressLocation, window } from "vscode";
 import { AppSettingsTreeItem, AppSettingTreeItem } from "vscode-azureappservice";
 import { AzExtParentTreeItem, AzExtTreeItem, AzureParentTreeItem, IActionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { AppSettingsClient } from "../commands/appSettings/AppSettingsClient";
 import { productionEnvironmentName } from "../constants";
+import { ext } from "../extensionVariables";
 import { tryGetBranch, tryGetRemote } from "../utils/gitHubUtils";
 import { localize } from "../utils/localize";
 import { openUrl } from "../utils/openUrl";
+import { requestUtils } from "../utils/requestUtils";
 import { treeUtils } from "../utils/treeUtils";
 import { ActionsTreeItem } from "./ActionsTreeItem";
 import { ActionTreeItem } from "./ActionTreeItem";
@@ -65,7 +68,7 @@ export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureRe
     }
 
     public get label(): string {
-        return this.data.properties.buildId === 'default' ? productionEnvironmentName : `#${this.name} - ${this.data.properties.pullRequestTitle}`;
+        return this.isProduction ? productionEnvironmentName : `#${this.name} - ${this.data.properties.pullRequestTitle}`;
     }
 
     public get description(): string {
@@ -77,12 +80,30 @@ export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureRe
         return treeUtils.getIconPath('Azure-Static-Apps-Environment');
     }
 
+    public get isProduction(): boolean {
+        return this.data.properties.buildId === 'default';
+    }
+
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtParentTreeItem[]> {
         return [this.actionsTreeItem, this.appSettingsTreeItem, this.functionsTreeItem];
     }
 
     public hasMoreChildrenImpl(): boolean {
         return false;
+    }
+
+    public async deleteTreeItemImpl(): Promise<void> {
+        const requestOptions: requestUtils.Request = await requestUtils.getDefaultAzureRequest(`${this.id}?api-version=2019-12-01-preview`, this.root, 'DELETE');
+        const deleting: string = localize('deleting', 'Deleting environment "{0}"...', this.label);
+
+        await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async (): Promise<void> => {
+            ext.outputChannel.appendLog(deleting);
+            await requestUtils.pollAzureAsyncOperation(requestOptions, this.root.credentials);
+
+            const deleteSucceeded: string = localize('deleteSucceeded', 'Successfully deleted environment "{0}".', this.label);
+            window.showInformationMessage(deleteSucceeded);
+            ext.outputChannel.appendLog(deleteSucceeded);
+        });
     }
 
     public async browse(): Promise<void> {

--- a/src/tree/StaticWebAppTreeItem.ts
+++ b/src/tree/StaticWebAppTreeItem.ts
@@ -3,12 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IncomingMessage } from 'ms-rest';
-import * as vscode from 'vscode';
+import { ProgressLocation, window } from "vscode";
 import { AzExtTreeItem, AzureParentTreeItem, IActionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { productionEnvironmentName } from '../constants';
 import { ext } from "../extensionVariables";
-import { delay } from '../utils/delay';
 import { getRepoFullname } from '../utils/gitHubUtils';
 import { localize } from "../utils/localize";
 import { openUrl } from '../utils/openUrl';
@@ -34,15 +32,6 @@ export type StaticWebApp = {
     };
     // tslint:disable-next-line:no-reserved-keywords
     type: string;
-};
-
-type AzureAsyncOperationResponse = {
-    id?: string;
-    status: string;
-    error?: {
-        code: string;
-        message: string;
-    };
 };
 
 export class StaticWebAppTreeItem extends AzureParentTreeItem implements IAzureResourceTreeItem {
@@ -114,47 +103,17 @@ export class StaticWebAppTreeItem extends AzureParentTreeItem implements IAzureR
         const requestOptions: requestUtils.Request = await requestUtils.getDefaultAzureRequest(`${this.id}?api-version=2019-12-01-preview`, this.root, 'DELETE');
         const deleting: string = localize('deleting', 'Deleting static web app "{0}"...', this.name);
 
-        await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: deleting }, async (): Promise<void> => {
+        await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async (): Promise<void> => {
             ext.outputChannel.appendLog(deleting);
-            await this.pollAzureAsyncOperation(requestOptions);
+            await requestUtils.pollAzureAsyncOperation(requestOptions, this.root.credentials);
 
             const deleteSucceeded: string = localize('deleteSucceeded', 'Successfully deleted static web app "{0}".', this.name);
-            vscode.window.showInformationMessage(deleteSucceeded);
+            window.showInformationMessage(deleteSucceeded);
             ext.outputChannel.appendLog(deleteSucceeded);
         });
     }
 
     public async browse(): Promise<void> {
         await openUrl(`https://${this.data.properties.defaultHostname}`);
-    }
-
-    //https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations
-    private async pollAzureAsyncOperation(asyncOperationRequest: requestUtils.Request): Promise<void> {
-        asyncOperationRequest.resolveWithFullResponse = true;
-        const asyncAzureRes: IncomingMessage = await requestUtils.sendRequest(asyncOperationRequest);
-        const monitorStatusUrl: string = <string>asyncAzureRes.headers['azure-asyncoperation'];
-        // the url already includes resourceManagerEndpointUrl, so just use getDefaultRequest instead
-        const monitorStatusReq: requestUtils.Request = await requestUtils.getDefaultRequest(monitorStatusUrl, this.root.credentials);
-
-        const timeoutInSeconds: number = 60;
-        const maxTime: number = Date.now() + timeoutInSeconds * 1000;
-        while (Date.now() < maxTime) {
-            const statusJsonString: string = await requestUtils.sendRequest(monitorStatusReq);
-            let operationResponse: AzureAsyncOperationResponse | undefined;
-            try {
-                operationResponse = <AzureAsyncOperationResponse>JSON.parse(statusJsonString);
-            } catch {
-                // swallow JSON parsing errors
-            }
-
-            if (operationResponse?.status !== 'InProgress') {
-                if (operationResponse?.error) {
-                    throw operationResponse.error;
-                }
-                return;
-            }
-
-            await delay(2000);
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/128

I decided to leave the label `Delete...` as is because `Delete Static Web App...` looks terrible.  Maybe I could just shorten it to App or Static App?

I'm using label for Environment's output messages because that's what the user is used to seeing.  The name property is just the build number (that's the name Azure gives it).

Moved the AzureAsyncRequest code to requestUtils, but we should be able to remove this once we move over to the new SDK.