### PR TITLE
Skip Select Location steps if ➕ new repo

### DIFF
--- a/src/commands/createStaticWebApp/ApiLocationStep.ts
+++ b/src/commands/createStaticWebApp/ApiLocationStep.ts
@@ -21,7 +21,7 @@ export class ApiLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardCo
     }
 
     public shouldPrompt(wizardContext: IStaticWebAppWizardContext): boolean {
-        return !wizardContext.apiLocation;
+        return !wizardContext.apiLocation && !wizardContext.newRepoName;
     }
 
     public async getSubWizard(wizardContext: IStaticWebAppWizardContext): Promise<IWizardOptions<IStaticWebAppWizardContext> | undefined> {

--- a/src/commands/createStaticWebApp/AppLocationStep.ts
+++ b/src/commands/createStaticWebApp/AppLocationStep.ts
@@ -21,7 +21,7 @@ export class AppLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardCo
     }
 
     public shouldPrompt(wizardContext: IStaticWebAppWizardContext): boolean {
-        return !wizardContext.appLocation;
+        return !wizardContext.appLocation && !wizardContext.newRepoName;
     }
 
     public async getSubWizard(wizardContext: IStaticWebAppWizardContext): Promise<IWizardOptions<IStaticWebAppWizardContext> | undefined> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/170

If a user creates a new repo, we obviously won't have a way to get their remote tree data.  When we allow users to create a new repo with their local git project, we should be able to have a more elegant solution than this, but for now, we can just skip the two location prompts and fallback to the sub-wizards instead (which was the old experience of typing it in).

The step count gets a little wonky after entering a repo name, but it's not too bad and stabilizes after the api location step.

![image](https://user-images.githubusercontent.com/5290572/88960222-09b47d80-d258-11ea-9389-1835805b2518.png)
![image](https://user-images.githubusercontent.com/5290572/88960241-133de580-d258-11ea-9eb5-04a47db7170a.png)
![image](https://user-images.githubusercontent.com/5290572/88960265-1d5fe400-d258-11ea-9251-295d9f0298cf.png)
![image](https://user-images.githubusercontent.com/5290572/88960294-2781e280-d258-11ea-9029-8798baa09f33.png)

