### PR TITLE
Add C# and Python 🐍 as supported language triggers

### DIFF
--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -42,7 +42,7 @@ async function getFunctionsApi(context: IActionContext): Promise<AzureFunctionsE
             await funcExtension.activate();
         }
 
-        return funcExtension.exports.getApi<AzureFunctionsExtensionApi>('^1.1.0');
+        return funcExtension.exports.getApi<AzureFunctionsExtensionApi>('^1.2.0');
     }
 
     await ext.ui.showWarningMessage(localize('funcInstall', 'You must have the "Azure Functions" extension installed to perform this operation.'), { title: 'Install' });

--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -6,7 +6,8 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { IActionContext } from "vscode-azureextensionui";
+import { IActionContext, UserCancelledError } from "vscode-azureextensionui";
+import { AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { apiSubpathSetting, defaultApiLocation } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../utils/localize';


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/185
Relies on https://github.com/microsoft/vscode-azurefunctions/pull/2355/files

I changed `return !(await fse.pathExists(path.join(folderPath, newName));` to `await fse.access(path.join(folderPath, newName));` because access will throw an error if it doesn't exist.  I felt like it made the logic a little simpler rather than doing pathExists, returning it if it's true, if it's false, go into another statement to check if the file exists, then try/catch that and return the result.