### PR TITLE
Move skip/manual enter closer to the top of qp list

### DIFF
--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -175,15 +175,20 @@ export async function getGitHubTree(repositoryUrl: string, branch: string): Prom
 export async function getGitTreeQuickPicks(wizardContext: IStaticWebAppWizardContext, isSkippable?: boolean): Promise<IAzureQuickPickItem<string | undefined>[]> {
     const gitTreeData: GitTreeData[] = await nonNullProp(wizardContext, 'gitTreeDataTask');
 
+    // Have quick pick items be in this following order: Skip for Now => Manually Enter => Root => Project folders
+    // If a user has more than 30+ folders, it's arduous for users to find the skip/manual button, so put it near the top
+
     const quickPicks: IAzureQuickPickItem<string | undefined>[] = gitTreeData.map((d) => { return { label: d.path, data: d.path }; });
+
+    const enterInputQuickPickItem: IAzureQuickPickItem = { label: localize('input', '$(keyboard) Manually enter location'), data: undefined };
+    quickPicks.unshift(enterInputQuickPickItem);
+
     // the root directory is not listed in the gitTreeData from GitHub, so just add it to the QuickPick list
     quickPicks.unshift({ label: '/', data: '/' });
-    const enterInputQuickPickItem: IAzureQuickPickItem = { label: localize('input', '$(keyboard) Manually enter location'), data: undefined };
-    quickPicks.push(enterInputQuickPickItem);
 
     const skipForNowQuickPickItem: IAzureQuickPickItem<string> = { label: localize('skipForNow', '$(clock) Skip for now'), data: '' };
     if (isSkippable) {
-        quickPicks.push(skipForNowQuickPickItem);
+        quickPicks.unshift(skipForNowQuickPickItem);
     }
 
     return quickPicks;

--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -180,14 +180,14 @@ export async function getGitTreeQuickPicks(wizardContext: IStaticWebAppWizardCon
 
     const quickPicks: IAzureQuickPickItem<string | undefined>[] = gitTreeData.map((d) => { return { label: d.path, data: d.path }; });
 
+    // the root directory is not listed in the gitTreeData from GitHub, so just add it to the QuickPick list
+    quickPicks.unshift({ label: './', data: '/' });
+
     const enterInputQuickPickItem: IAzureQuickPickItem = { label: localize('input', '$(keyboard) Manually enter location'), data: undefined };
     quickPicks.unshift(enterInputQuickPickItem);
 
-    // the root directory is not listed in the gitTreeData from GitHub, so just add it to the QuickPick list
-    quickPicks.unshift({ label: '/', data: '/' });
-
-    const skipForNowQuickPickItem: IAzureQuickPickItem<string> = { label: localize('skipForNow', '$(clock) Skip for now'), data: '' };
     if (isSkippable) {
+        const skipForNowQuickPickItem: IAzureQuickPickItem<string> = { label: localize('skipForNow', '$(clock) Skip for now'), data: '' };
         quickPicks.unshift(skipForNowQuickPickItem);
     }
 


### PR DESCRIPTION
Co-authored with @johnpapa 

As mentioned in this PR https://github.com/microsoft/vscode-azurestaticwebapps/pull/208, Skip for Now and Manual Enter being at the bottom really hurts users with repos more than 20-30 folders.  Which, since our logic looks into subfolders as well, seems very likely to happen.

I also changed the label for root because it looked so strange to just be a slash.

Before:
![image](https://user-images.githubusercontent.com/5290572/96294013-90980d00-0fa0-11eb-8e32-0e38c4788bea.png)

After:
![image](https://user-images.githubusercontent.com/5290572/96294040-9988de80-0fa0-11eb-85f1-d6f02568fa1e.png)
