### PR TITLE
Remove github username from source branch

### DIFF
--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -58,6 +58,12 @@ export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureRe
         this.branch = nonNullProp(this.data, 'sourceBranch');
 
         this.isProduction = this.buildId === 'default';
+
+        // StaticSiteBuild source branch is formatted as GitHubAccount:branch name for non-production builds
+        // split the : because branch names cannot contain colons
+        if (!this.isProduction) {
+            this.branch = this.branch.split(':')[1];
+        }
         this.label = this.isProduction ? productionEnvironmentName : `${this.data.pullRequestTitle}`;
     }
 

--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -62,7 +62,10 @@ export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureRe
         // StaticSiteBuild source branch is formatted as GitHubAccount:branch name for non-production builds
         // split the : because branch names cannot contain colons
         if (!this.isProduction) {
-            this.branch = this.branch.split(':')[1];
+            const colon: string = ':';
+            if (this.branch.includes(colon)) {
+                this.branch = this.branch.split(colon)[1];
+            }
         }
         this.label = this.isProduction ? productionEnvironmentName : `${this.data.pullRequestTitle}`;
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/195

The API now returns source branch as `githubUsername:sourceBranch` for any build that is not the production.  Really strange behavior, but you can see it here
![image](https://user-images.githubusercontent.com/5290572/97647759-4ab35e00-1a10-11eb-9203-fed73a2c8965.png)
And here on the Portal as well
![image](https://user-images.githubusercontent.com/5290572/97647788-5868e380-1a10-11eb-9b06-079ae24774c6.png)

I don't have any older SWAs with an environment to see if this was a retroactive change or not.  Branch names are not allowed to have a colon though, so my split should be safe.
