### PR TITLE
Check for no remote branches

### DIFF
--- a/src/commands/createStaticWebApp/GitHubBranchListStep.ts
+++ b/src/commands/createStaticWebApp/GitHubBranchListStep.ts
@@ -38,6 +38,8 @@ export class GitHubBranchListStep extends AzureWizardPromptStep<IStaticWebAppWiz
 
     private async getBranchPicks(context: IStaticWebAppWizardContext, params: ReposListBranchesParameters, picksCache: ICachedQuickPicks<BranchData>): Promise<IAzureQuickPickItem<BranchData | undefined>[]> {
         const client: Octokit = await createOctokitClient(context.accessToken);
-        return await getGitHubQuickPicksWithLoadMore<BranchData, ReposListBranchesParameters>(picksCache, client.repos.listBranches, params, 'name');
+        const picks: IAzureQuickPickItem<BranchData | undefined>[] = await getGitHubQuickPicksWithLoadMore<BranchData, ReposListBranchesParameters>(picksCache, client.repos.listBranches, params, 'name');
+        const noBranch: string = localize('noBranch', ' $(stop) No branches detected. Go back to select a different repository or create a remote branch');
+        return picks.length > 0 ? picks : [{ label: noBranch, data: undefined }];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/117

While ideally, we could just create a remote branch for the user, it's a complicated UI experience due to the fact that we can't guarantee that the repo they selected is what they currently have in the local workspace.  GitHub doesn't have an API call to create a new branch (as far as I know) so an error message seems better than nothing.

If anyone knows how to make it more of an error message or change the color of the message/icon, let me know.  I looked through the VS Code API and didn't see anything about it.

Before: 
![image](https://user-images.githubusercontent.com/5290572/98178604-de25dc80-1eb1-11eb-8978-f895c84c563b.png)

After:
![image](https://user-images.githubusercontent.com/5290572/98178622-e54cea80-1eb1-11eb-8582-2bfb2c395908.png)

