### PR TITLE
Add git to getExtensionApi file

### DIFF
--- a/src/commands/appSettings/downloadAppSettings.ts
+++ b/src/commands/appSettings/downloadAppSettings.ts
@@ -6,7 +6,7 @@
 import { AppSettingsTreeItem, IAppSettingsClient } from 'vscode-azureappservice';
 import { IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
-import { getFunctionsApi } from '../../getFunctionsApi';
+import { getFunctionsApi } from '../../getExtensionApi';
 import { localize } from "../../utils/localize";
 import { AzureFunctionsExtensionApi } from '../../vscode-azurefunctions.api';
 

--- a/src/commands/appSettings/uploadAppSettings.ts
+++ b/src/commands/appSettings/uploadAppSettings.ts
@@ -6,7 +6,7 @@
 import { AppSettingsTreeItem, IAppSettingsClient } from 'vscode-azureappservice';
 import { IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
-import { getFunctionsApi } from '../../getFunctionsApi';
+import { getFunctionsApi } from '../../getExtensionApi';
 import { localize } from "../../utils/localize";
 import { AzureFunctionsExtensionApi } from '../../vscode-azurefunctions.api';
 

--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { workspace } from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
 import { apiSubpathSetting, defaultApiLocation } from '../constants';
-import { getFunctionsApi } from '../getFunctionsApi';
+import { getFunctionsApi } from '../getExtensionApi';
 import { localize } from '../utils/localize';
 import { getWorkspaceSetting } from '../utils/settingsUtils';
 import { AzureFunctionsExtensionApi } from '../vscode-azurefunctions.api';

--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -7,6 +7,7 @@ import { commands, Extension, extensions } from "vscode";
 import { IActionContext, UserCancelledError } from "vscode-azureextensionui";
 import { AzureExtensionApiProvider } from "vscode-azureextensionui/api";
 import { ext } from "./extensionVariables";
+import { API, GitExtension } from "./git";
 import { localize } from "./utils/localize";
 import { AzureFunctionsExtensionApi } from "./vscode-azurefunctions.api";
 
@@ -30,3 +31,15 @@ export async function getFunctionsApi(context: IActionContext): Promise<AzureFun
     // we still need to throw an error even if the user installs
     throw new UserCancelledError();
 }
+
+export async function getGitApi(): Promise<API> {
+    try {
+        const gitExtension: Extension<GitExtension> | undefined = extensions.getExtension<GitExtension>('vscode.git');
+        if (gitExtension) {
+            return gitExtension.exports.getAPI(1);
+        }
+    } catch (err) {
+        // the getExtension error is very vague and unactionable so swallow and throw our own error
+    }
+
+    throw new Error(localize('gitEnabled', 'If you would like to use git features, please enable git in your [settings](command:workbench.action.openSettings?%5B%22git.enabled%22%5D). To learn more about how to use git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).'));

--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -13,14 +13,10 @@ import { AzureFunctionsExtensionApi } from "./vscode-azurefunctions.api";
 
 export async function getFunctionsApi(context: IActionContext): Promise<AzureFunctionsExtensionApi> {
     const funcExtensionId: string = 'ms-azuretools.vscode-azurefunctions';
-    const funcExtension: Extension<AzureExtensionApiProvider> | undefined = extensions.getExtension(funcExtensionId);
+    const funcExtension: AzureExtensionApiProvider | undefined = await getApiExport(funcExtensionId);
 
     if (funcExtension) {
-        if (!funcExtension.isActive) {
-            await funcExtension.activate();
-        }
-
-        return funcExtension.exports.getApi<AzureFunctionsExtensionApi>('^1.3.0');
+        return funcExtension.getApi<AzureFunctionsExtensionApi>('^1.3.0');
     }
 
     await ext.ui.showWarningMessage(localize('funcInstall', 'You must have the "Azure Functions" extension installed to perform this operation.'), { title: 'Install' });
@@ -34,12 +30,26 @@ export async function getFunctionsApi(context: IActionContext): Promise<AzureFun
 
 export async function getGitApi(): Promise<API> {
     try {
-        const gitExtension: Extension<GitExtension> | undefined = extensions.getExtension<GitExtension>('vscode.git');
+        const gitExtension: GitExtension | undefined = await getApiExport('vscode.git');
         if (gitExtension) {
-            return gitExtension.exports.getAPI(1);
+            return gitExtension.getAPI(1);
         }
     } catch (err) {
         // the getExtension error is very vague and unactionable so swallow and throw our own error
     }
 
     throw new Error(localize('gitEnabled', 'If you would like to use git features, please enable git in your [settings](command:workbench.action.openSettings?%5B%22git.enabled%22%5D). To learn more about how to use git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).'));
+}
+
+export async function getApiExport<T>(extensionId: string): Promise<T | undefined> {
+    const extension: Extension<T> | undefined = extensions.getExtension(extensionId);
+    if (extension) {
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+
+        return extension.exports;
+    }
+
+    return undefined;
+}

--- a/src/git.d.ts
+++ b/src/git.d.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// copied from https://github.com/microsoft/vscode/blob/master/extensions/git/src/api/git.d.ts
 import { Disposable, Event, ProviderResult, Uri } from 'vscode';
 export { ProviderResult } from 'vscode';
 

--- a/src/git.d.ts
+++ b/src/git.d.ts
@@ -1,0 +1,304 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, Event, ProviderResult, Uri } from 'vscode';
+export { ProviderResult } from 'vscode';
+
+export interface Git {
+    readonly path: string;
+}
+
+export interface InputBox {
+    value: string;
+}
+
+export const enum RefType {
+    Head,
+    RemoteHead,
+    Tag
+}
+
+export interface Ref {
+    readonly type: RefType;
+    readonly name?: string;
+    readonly commit?: string;
+    readonly remote?: string;
+}
+
+export interface UpstreamRef {
+    readonly remote: string;
+    readonly name: string;
+}
+
+export interface Branch extends Ref {
+    readonly upstream?: UpstreamRef;
+    readonly ahead?: number;
+    readonly behind?: number;
+}
+
+export interface Commit {
+    readonly hash: string;
+    readonly message: string;
+    readonly parents: string[];
+    readonly authorDate?: Date;
+    readonly authorName?: string;
+    readonly authorEmail?: string;
+    readonly commitDate?: Date;
+}
+
+export interface Submodule {
+    readonly name: string;
+    readonly path: string;
+    readonly url: string;
+}
+
+export interface Remote {
+    readonly name: string;
+    readonly fetchUrl?: string;
+    readonly pushUrl?: string;
+    readonly isReadOnly: boolean;
+}
+
+export const enum Status {
+    INDEX_MODIFIED,
+    INDEX_ADDED,
+    INDEX_DELETED,
+    INDEX_RENAMED,
+    INDEX_COPIED,
+
+    MODIFIED,
+    DELETED,
+    UNTRACKED,
+    IGNORED,
+    INTENT_TO_ADD,
+
+    ADDED_BY_US,
+    ADDED_BY_THEM,
+    DELETED_BY_US,
+    DELETED_BY_THEM,
+    BOTH_ADDED,
+    BOTH_DELETED,
+    BOTH_MODIFIED
+}
+
+export interface Change {
+
+    /**
+     * Returns either `originalUri` or `renameUri`, depending
+     * on whether this change is a rename change. When
+     * in doubt always use `uri` over the other two alternatives.
+     */
+    readonly uri: Uri;
+    readonly originalUri: Uri;
+    readonly renameUri: Uri | undefined;
+    readonly status: Status;
+}
+
+export interface RepositoryState {
+    readonly HEAD: Branch | undefined;
+    readonly refs: Ref[];
+    readonly remotes: Remote[];
+    readonly submodules: Submodule[];
+    readonly rebaseCommit: Commit | undefined;
+
+    readonly mergeChanges: Change[];
+    readonly indexChanges: Change[];
+    readonly workingTreeChanges: Change[];
+
+    readonly onDidChange: Event<void>;
+}
+
+export interface RepositoryUIState {
+    readonly selected: boolean;
+    readonly onDidChange: Event<void>;
+}
+
+/**
+ * Log options.
+ */
+export interface LogOptions {
+    /** Max number of log entries to retrieve. If not specified, the default is 32. */
+    readonly maxEntries?: number;
+    readonly path?: string;
+}
+
+export interface CommitOptions {
+    all?: boolean | 'tracked';
+    amend?: boolean;
+    signoff?: boolean;
+    signCommit?: boolean;
+    empty?: boolean;
+    noVerify?: boolean;
+}
+
+export interface BranchQuery {
+    readonly remote?: boolean;
+    readonly pattern?: string;
+    readonly count?: number;
+    readonly contains?: string;
+}
+
+export interface Repository {
+
+    readonly rootUri: Uri;
+    readonly inputBox: InputBox;
+    readonly state: RepositoryState;
+    readonly ui: RepositoryUIState;
+
+    getConfigs(): Promise<{ key: string; value: string; }[]>;
+    getConfig(key: string): Promise<string>;
+    setConfig(key: string, value: string): Promise<string>;
+    getGlobalConfig(key: string): Promise<string>;
+
+    getObjectDetails(treeish: string, path: string): Promise<{ mode: string, object: string, size: number }>;
+    detectObjectType(object: string): Promise<{ mimetype: string, encoding?: string }>;
+    buffer(ref: string, path: string): Promise<Buffer>;
+    show(ref: string, path: string): Promise<string>;
+    getCommit(ref: string): Promise<Commit>;
+
+    clean(paths: string[]): Promise<void>;
+
+    apply(patch: string, reverse?: boolean): Promise<void>;
+    diff(cached?: boolean): Promise<string>;
+    diffWithHEAD(): Promise<Change[]>;
+    diffWithHEAD(path: string): Promise<string>;
+    diffWith(ref: string): Promise<Change[]>;
+    diffWith(ref: string, path: string): Promise<string>;
+    diffIndexWithHEAD(): Promise<Change[]>;
+    diffIndexWithHEAD(path: string): Promise<string>;
+    diffIndexWith(ref: string): Promise<Change[]>;
+    diffIndexWith(ref: string, path: string): Promise<string>;
+    diffBlobs(object1: string, object2: string): Promise<string>;
+    diffBetween(ref1: string, ref2: string): Promise<Change[]>;
+    diffBetween(ref1: string, ref2: string, path: string): Promise<string>;
+
+    hashObject(data: string): Promise<string>;
+
+    createBranch(name: string, checkout: boolean, ref?: string): Promise<void>;
+    deleteBranch(name: string, force?: boolean): Promise<void>;
+    getBranch(name: string): Promise<Branch>;
+    getBranches(query: BranchQuery): Promise<Ref[]>;
+    setBranchUpstream(name: string, upstream: string): Promise<void>;
+
+    getMergeBase(ref1: string, ref2: string): Promise<string>;
+
+    status(): Promise<void>;
+    checkout(treeish: string): Promise<void>;
+
+    addRemote(name: string, url: string): Promise<void>;
+    removeRemote(name: string): Promise<void>;
+    renameRemote(name: string, newName: string): Promise<void>;
+
+    fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
+    pull(unshallow?: boolean): Promise<void>;
+    push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
+
+    blame(path: string): Promise<string>;
+    log(options?: LogOptions): Promise<Commit[]>;
+
+    commit(message: string, opts?: CommitOptions): Promise<void>;
+}
+
+export interface RemoteSource {
+    readonly name: string;
+    readonly description?: string;
+    readonly url: string | string[];
+}
+
+export interface RemoteSourceProvider {
+    readonly name: string;
+    readonly icon?: string; // codicon name
+    readonly supportsQuery?: boolean;
+    getRemoteSources(query?: string): ProviderResult<RemoteSource[]>;
+    publishRepository?(repository: Repository): Promise<void>;
+}
+
+export interface Credentials {
+    readonly username: string;
+    readonly password: string;
+}
+
+export interface CredentialsProvider {
+    getCredentials(host: Uri): ProviderResult<Credentials>;
+}
+
+export interface PushErrorHandler {
+    handlePushError(repository: Repository, remote: Remote, refspec: string, error: Error & { gitErrorCode: GitErrorCodes }): Promise<boolean>;
+}
+
+export type APIState = 'uninitialized' | 'initialized';
+
+export interface API {
+    readonly state: APIState;
+    readonly onDidChangeState: Event<APIState>;
+    readonly git: Git;
+    readonly repositories: Repository[];
+    readonly onDidOpenRepository: Event<Repository>;
+    readonly onDidCloseRepository: Event<Repository>;
+
+    toGitUri(uri: Uri, ref: string): Uri;
+    init(root: Uri): Promise<Repository | null>;
+    getRepository(uri: Uri): Repository | null;
+
+    registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable;
+    registerCredentialsProvider(provider: CredentialsProvider): Disposable;
+    registerPushErrorHandler(handler: PushErrorHandler): Disposable;
+}
+
+export interface GitExtension {
+
+    readonly enabled: boolean;
+    readonly onDidChangeEnablement: Event<boolean>;
+
+    /**
+     * Returns a specific API version.
+     *
+     * Throws error if git extension is disabled. You can listed to the
+     * [GitExtension.onDidChangeEnablement](#GitExtension.onDidChangeEnablement) event
+     * to know when the extension becomes enabled/disabled.
+     *
+     * @param version Version number.
+     * @returns API instance
+     */
+    getAPI(version: 1): API;
+}
+
+export const enum GitErrorCodes {
+    BadConfigFile = 'BadConfigFile',
+    AuthenticationFailed = 'AuthenticationFailed',
+    NoUserNameConfigured = 'NoUserNameConfigured',
+    NoUserEmailConfigured = 'NoUserEmailConfigured',
+    NoRemoteRepositorySpecified = 'NoRemoteRepositorySpecified',
+    NotAGitRepository = 'NotAGitRepository',
+    NotAtRepositoryRoot = 'NotAtRepositoryRoot',
+    Conflict = 'Conflict',
+    StashConflict = 'StashConflict',
+    UnmergedChanges = 'UnmergedChanges',
+    PushRejected = 'PushRejected',
+    RemoteConnectionError = 'RemoteConnectionError',
+    DirtyWorkTree = 'DirtyWorkTree',
+    CantOpenResource = 'CantOpenResource',
+    GitNotFound = 'GitNotFound',
+    CantCreatePipe = 'CantCreatePipe',
+    PermissionDenied = 'PermissionDenied',
+    CantAccessRemote = 'CantAccessRemote',
+    RepositoryNotFound = 'RepositoryNotFound',
+    RepositoryIsLocked = 'RepositoryIsLocked',
+    BranchNotFullyMerged = 'BranchNotFullyMerged',
+    NoRemoteReference = 'NoRemoteReference',
+    InvalidBranchName = 'InvalidBranchName',
+    BranchAlreadyExists = 'BranchAlreadyExists',
+    NoLocalChanges = 'NoLocalChanges',
+    NoStashFound = 'NoStashFound',
+    LocalChangesOverwritten = 'LocalChangesOverwritten',
+    NoUpstreamBranch = 'NoUpstreamBranch',
+    IsInSubmodule = 'IsInSubmodule',
+    WrongCase = 'WrongCase',
+    CantLockRef = 'CantLockRef',
+    CantRebaseMultipleBranches = 'CantRebaseMultipleBranches',
+    PatchDoesNotApply = 'PatchDoesNotApply',
+    NoPathFound = 'NoPathFound',
+    UnknownPath = 'UnknownPath',
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "exclude": [
         "node_modules",
         ".vscode-test",
-        "gulpfile.ts"
+        "gulpfile.ts",
+        "src/vscode-azurefunctions.api.d.ts"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
     "exclude": [
         "node_modules",
         ".vscode-test",
-        "gulpfile.ts",
-        "src/vscode-azurefunctions.api.d.ts"
+        "gulpfile.ts"
     ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,7 @@
     "extends": "tslint-microsoft-contrib",
     "linterOptions": {
         "exclude": [
-            "src/vscode-azurefunctions.api.d.ts"
+            "**/*.d.ts"
         ]
     },
     "rules": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,10 @@
 {
     "extends": "tslint-microsoft-contrib",
+    "linterOptions": {
+        "exclude": [
+            "src/vscode-azurefunctions.api.d.ts"
+        ]
+    },
     "rules": {
         "await-promise": [
             true,


### PR DESCRIPTION
Refactored from: https://github.com/microsoft/vscode-azurestaticwebapps/pull/246

I need the git api for some other things and thought it would just make code review a little simpler.  While I'm not using the gitApi in the codebase yet, another PR will follow shortly (plus there's #246 if you need an example of how it'll be used)