### PR TITLE
Check for bad credentials/ sign-out automatically

### DIFF
--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -103,9 +103,19 @@ export async function getGitHubQuickPicksWithLoadMore<TResult, TParams>(
     }
 }
 
+const githubProviderId: string = 'github';
+const scopes: string[] = ['repo', 'workflow', 'admin:public_key'];
+
 export async function getGitHubAccessToken(): Promise<string> {
-    const scopes: string[] = ['repo', 'workflow', 'admin:public_key'];
-    return (await authentication.getSession('github', scopes, { createIfNone: true })).accessToken;
+    return (await authentication.getSession(githubProviderId, scopes, { createIfNone: true })).accessToken;
+}
+
+export async function logoutOfGitHubSession(): Promise<void> {
+    const sessionId: string | undefined = (await authentication.getSession(githubProviderId, scopes))?.id;
+
+    if (sessionId) {
+        await authentication.logout(githubProviderId, sessionId);
+    }
 }
 
 export async function tryGetRemote(): Promise<ReposGetResponseData | undefined> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/197

Doesn't seem like this happens frequently, but basically if you revoke your token access in GitHub Developer's Settings while you have VS Code opened, VS Code won't recognize that the token is invalid now so any action throws "Bad credentials".  This is resolved by either logging out of session or by restarting VS Code, but it's kind of hard to discover that.

I only validate when no token is passed in since it'd be annoying to add an extra API call for each step of the wizard that uses Octokit client.