### PR TITLE
Change msg when creating swa and reveal actions node

### DIFF
--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -20,7 +20,7 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
 
     const swaNode: StaticWebAppTreeItem = await node.createChild(context);
 
-    const createdSs: string = localize('createdSs', 'Successfully created new static web app "{0}".  The GitHub Action must complete before your Static Web App will receive the deployed content.', swaNode.name);
+    const createdSs: string = localize('createdSs', 'Successfully created new static web app "{0}".  GitHub Actions is building and deploying your app, it will be available once the deployment completes.', swaNode.name);
     ext.outputChannel.appendLog(createdSs);
 
     const showActionsMsg: MessageItem = { title: localize('openActions', 'Open Actions in GitHub') };

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -6,9 +6,11 @@
 import { MessageItem, window } from 'vscode';
 import { IActionContext, ICreateChildImplContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
+import { EnvironmentTreeItem } from '../../tree/EnvironmentTreeItem';
 import { StaticWebAppTreeItem } from '../../tree/StaticWebAppTreeItem';
 import { SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
 import { localize } from '../../utils/localize';
+import { revealTreeItem } from '../api/revealTreeItem';
 import { showActions } from '../github/showActions';
 
 export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext>, node?: SubscriptionTreeItem): Promise<StaticWebAppTreeItem> {
@@ -18,7 +20,7 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
 
     const swaNode: StaticWebAppTreeItem = await node.createChild(context);
 
-    const createdSs: string = localize('createdSs', 'Successfully created new static web app "{0}".', swaNode.name);
+    const createdSs: string = localize('createdSs', 'Successfully created new static web app "{0}".  The GitHub Action must complete before your Static Web App will receive the deployed content.', swaNode.name);
     ext.outputChannel.appendLog(createdSs);
 
     const showActionsMsg: MessageItem = { title: localize('openActions', 'Open Actions in GitHub') };
@@ -31,6 +33,8 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
             ext.outputChannel.show();
         }
     });
+    const children: EnvironmentTreeItem = <EnvironmentTreeItem>(await swaNode.loadAllChildren(context))[0]; // since it's newly created, should only have the environment tree node
+    await revealTreeItem(children.actionsTreeItem.fullId);
 
     return swaNode;
 }

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -6,11 +6,9 @@
 import { MessageItem, window } from 'vscode';
 import { IActionContext, ICreateChildImplContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
-import { EnvironmentTreeItem } from '../../tree/EnvironmentTreeItem';
 import { StaticWebAppTreeItem } from '../../tree/StaticWebAppTreeItem';
 import { SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
 import { localize } from '../../utils/localize';
-import { revealTreeItem } from '../api/revealTreeItem';
 import { showActions } from '../github/showActions';
 
 export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext>, node?: SubscriptionTreeItem): Promise<StaticWebAppTreeItem> {
@@ -33,8 +31,6 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
             ext.outputChannel.show();
         }
     });
-    const children: EnvironmentTreeItem = <EnvironmentTreeItem>(await swaNode.loadAllChildren(context))[0]; // since it's newly created, should only have the environment tree node
-    await revealTreeItem(children.actionsTreeItem.fullId);
 
     return swaNode;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/249

Based off the feedback, I'd like to make it painfully obvious that the action needs to finish before you can access the SWA.  @fiveisprime you might have to help me with the wording of the message a bit though.

I thought it'd help to just reveal the tree item to the user as well so they can see that the action is running.