### PR TITLE
Use retry logic to check status and refresh when workflow completes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -637,11 +637,6 @@
                 "@types/request": "*"
             }
         },
-        "@types/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
-        },
         "@types/source-list-map": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -6097,15 +6092,6 @@
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
             "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
             "dev": true
-        },
-        "p-retry": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-            "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
-            "requires": {
-                "@types/retry": "^0.12.0",
-                "retry": "^0.12.0"
-            }
         },
         "p-try": {
             "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -637,6 +637,11 @@
                 "@types/request": "*"
             }
         },
+        "@types/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+        },
         "@types/source-list-map": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -6094,10 +6099,11 @@
             "dev": true
         },
         "p-retry": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
-            "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+            "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
             "requires": {
+                "@types/retry": "^0.12.0",
                 "retry": "^0.12.0"
             }
         },
@@ -8379,6 +8385,14 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
                     "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+                },
+                "p-retry": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+                    "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+                    "requires": {
+                        "retry": "^0.12.0"
+                    }
                 },
                 "safe-buffer": {
                     "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -467,6 +467,7 @@
         "fs-extra": "^8.1.0",
         "git-url-parse": "^11.1.2",
         "moment": "^2.27.0",
+        "p-retry": "^4.2.0",
         "simple-git": "^1.132.0",
         "vscode-azureappservice": "^0.65.0",
         "vscode-azureextensionui": "^0.35.1",

--- a/package.json
+++ b/package.json
@@ -467,7 +467,6 @@
         "fs-extra": "^8.1.0",
         "git-url-parse": "^11.1.2",
         "moment": "^2.27.0",
-        "p-retry": "^4.2.0",
         "simple-git": "^1.132.0",
         "vscode-azureappservice": "^0.65.0",
         "vscode-azureextensionui": "^0.35.1",

--- a/src/commands/github/actionCommands.ts
+++ b/src/commands/github/actionCommands.ts
@@ -5,16 +5,14 @@
 
 import { Octokit } from "@octokit/rest";
 import { ActionsGetWorkflowRunResponseData } from "@octokit/types";
-import * as retry from 'p-retry';
-import { CancellationToken, CancellationTokenSource, window } from "vscode";
-import { IActionContext, parseError, UserCancelledError } from "vscode-azureextensionui";
+import { window } from "vscode";
+import { IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { ActionTreeItem } from "../../tree/ActionTreeItem";
 import { ensureStatus } from "../../utils/actionUtils";
+import { pollAsyncOperation } from "../../utils/azureUtils";
 import { localize } from "../../utils/localize";
 import { createOctokitClient } from "./createOctokitClient";
-
-const activeActionTokens: { [key: string]: CancellationTokenSource | undefined } = {};
 
 export async function rerunAction(context: IActionContext, node?: ActionTreeItem): Promise<void> {
     if (!node) {
@@ -45,58 +43,27 @@ export async function cancelAction(context: IActionContext, node?: ActionTreeIte
 }
 
 async function checkActionStatus(context: IActionContext, node: ActionTreeItem, action: 'rerun' | 'cancel'): Promise<void> {
-    // realistically, we have no idea how long someone's build can take, but might as well keep retrying while VS Code is opened
-    const tokenSource: CancellationTokenSource = new CancellationTokenSource();
-    const token: CancellationToken = tokenSource.token;
-    if (activeActionTokens[node.data.id]) {
-        activeActionTokens[node.data.id]?.cancel();
-    }
-
-    activeActionTokens[node.data.id] = tokenSource;
-
-    const retries: number = 10;
     const startTime: number = Date.now();
-    const notCompleteError: string = localize('notComplete', 'Action "{0}" has not completed.', node.data.id);
-    const cancelled: string = 'Action cancelled by user';
-    try {
-        await retry(
-            async () => {
-                if (token?.isCancellationRequested) {
-                    throw new retry.AbortError(cancelled);
-                }
-
-                const client: Octokit = await createOctokitClient();
-                const workflowRun: ActionsGetWorkflowRunResponseData = (await client.actions.getWorkflowRun({ owner: node.data.repository.owner.login, repo: node.data.repository.name, run_id: node.data.id })).data;
-                if (ensureStatus(workflowRun) === 'completed') {
-                    const actionCompleted: string = localize('actionCompleted', 'Action "{0}" has completed with the conclusion "{1}".', node.data.id, workflowRun.conclusion);
-                    ext.outputChannel.appendLog(actionCompleted);
-                    window.showInformationMessage(actionCompleted);
-                    await node.refresh();
-                    context.telemetry.properties.secToReport = String((Date.now() - startTime) / 1000);
-                    context.telemetry.properties.conclusion = workflowRun.conclusion;
-                    context.telemetry.properties.action = action;
-                    return;
-                }
-
-                throw new Error(notCompleteError);
-            },
-            {
-                onFailedAttempt: error => {
-                    if (parseError(error).message !== notCompleteError) {
-                        throw error;
-                    }
-                },
-                retries, minTimeout: 5 * 1000,
-            });
-    } catch (error) {
-        if (parseError(error).message === cancelled) {
-            throw new UserCancelledError();
+    const client: Octokit = await createOctokitClient();
+    const pollingOperation: () => Promise<boolean> = async () => {
+        const workflowRun: ActionsGetWorkflowRunResponseData = (await client.actions.getWorkflowRun({ owner: node.data.repository.owner.login, repo: node.data.repository.name, run_id: node.data.id })).data;
+        if (ensureStatus(workflowRun) === 'completed') {
+            const actionCompleted: string = localize('actionCompleted', 'Action "{0}" has completed with the conclusion "{1}".', node.data.id, workflowRun.conclusion);
+            ext.outputChannel.appendLog(actionCompleted);
+            window.showInformationMessage(actionCompleted);
+            await node.refresh();
+            context.telemetry.properties.secToReport = String((Date.now() - startTime) / 1000);
+            context.telemetry.properties.conclusion = workflowRun.conclusion;
+            context.telemetry.properties.action = action;
+            return true;
         }
 
-        throw error;
-    } finally {
-        activeActionTokens[node.data.id] = undefined;
-        tokenSource.dispose();
-    }
+        return false;
+    };
 
+    if (!await pollAsyncOperation(pollingOperation, 15, 20 * 60, String(node.data.id))) {
+        const operationTimedOut: string = localize('timedOut', 'The action "{0}" is still running.  Check "{1}" for its status', node.data.id, node.data.html_url);
+        ext.outputChannel.appendLog(operationTimedOut);
+        window.showInformationMessage(operationTimedOut);
+    }
 }

--- a/src/commands/github/actionCommands.ts
+++ b/src/commands/github/actionCommands.ts
@@ -4,11 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Octokit } from "@octokit/rest";
-import { IActionContext } from "vscode-azureextensionui";
+import { ActionsGetWorkflowRunResponseData } from "@octokit/types";
+import * as retry from 'p-retry';
+import { CancellationToken, CancellationTokenSource, window } from "vscode";
+import { IActionContext, parseError, UserCancelledError } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { ActionTreeItem } from "../../tree/ActionTreeItem";
 import { localize } from "../../utils/localize";
 import { createOctokitClient } from "./createOctokitClient";
+
+const activeActionTokens: { [key: string]: CancellationTokenSource | undefined } = {};
 
 export async function rerunAction(context: IActionContext, node?: ActionTreeItem): Promise<void> {
     if (!node) {
@@ -21,6 +26,7 @@ export async function rerunAction(context: IActionContext, node?: ActionTreeItem
     const client: Octokit = await createOctokitClient();
     await client.actions.reRunWorkflow({ owner: node.data.repository.owner.login, repo: node.data.repository.name, run_id: node.data.id });
     await node.refresh(); // need to refresh to update the data
+    await checkActionStatus(context, node, 'rerun');
 }
 
 export async function cancelAction(context: IActionContext, node?: ActionTreeItem): Promise<void> {
@@ -34,4 +40,62 @@ export async function cancelAction(context: IActionContext, node?: ActionTreeIte
     const client: Octokit = await createOctokitClient();
     await client.actions.cancelWorkflowRun({ owner: node.data.repository.owner.login, repo: node.data.repository.name, run_id: node.data.id });
     await node.refresh(); // need to refresh to update the data
+    await checkActionStatus(context, node, 'cancel');
+}
+
+async function checkActionStatus(context: IActionContext, node: ActionTreeItem, action: 'rerun' | 'cancel'): Promise<void> {
+    // realistically, we have no idea how long someone's build can take, but might as well keep retrying while VS Code is opened
+    const tokenSource: CancellationTokenSource = new CancellationTokenSource();
+    const token: CancellationToken = tokenSource.token;
+    if (activeActionTokens[node.data.id]) {
+        activeActionTokens[node.data.id]?.cancel();
+    }
+
+    activeActionTokens[node.data.id] = tokenSource;
+
+    const retries: number = 10;
+    const startTime: number = Date.now();
+    const notCompleteError: string = localize('notComplete', 'Action "{0}" has not completed.', node.data.id);
+    const cancelled: string = 'Action cancelled by user';
+    try {
+        await retry(
+            async () => {
+                if (token?.isCancellationRequested) {
+                    throw new retry.AbortError(cancelled);
+                }
+
+                const client: Octokit = await createOctokitClient();
+                const workflowRun: ActionsGetWorkflowRunResponseData = (await client.actions.getWorkflowRun({ owner: node.data.repository.owner.login, repo: node.data.repository.name, run_id: node.data.id })).data;
+                if (workflowRun.status === 'completed') {
+                    const actionCompleted: string = localize('actionCompleted', 'Action "{0}" has completed with the conclusion "{1}".', node.data.id, workflowRun.conclusion);
+                    ext.outputChannel.appendLog(actionCompleted);
+                    window.showInformationMessage(actionCompleted);
+                    await node.refresh();
+                    context.telemetry.properties.secToReport = String((Date.now() - startTime) / 1000);
+                    context.telemetry.properties.conclusion = workflowRun.conclusion;
+                    context.telemetry.properties.action = action;
+                    return;
+                }
+
+                throw new Error(notCompleteError);
+            },
+            {
+                onFailedAttempt: error => {
+                    if (parseError(error).message !== notCompleteError) {
+                        throw error;
+                    }
+                },
+                retries, minTimeout: 5 * 1000,
+            });
+    } catch (error) {
+        if (parseError(error).message === cancelled) {
+            throw new UserCancelledError();
+        }
+
+        throw error;
+    } finally {
+        activeActionTokens[node.data.id] = undefined;
+        tokenSource.dispose();
+    }
+
 }

--- a/src/commands/github/actionCommands.ts
+++ b/src/commands/github/actionCommands.ts
@@ -10,6 +10,7 @@ import { CancellationToken, CancellationTokenSource, window } from "vscode";
 import { IActionContext, parseError, UserCancelledError } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { ActionTreeItem } from "../../tree/ActionTreeItem";
+import { ensureStatus } from "../../utils/actionUtils";
 import { localize } from "../../utils/localize";
 import { createOctokitClient } from "./createOctokitClient";
 
@@ -66,7 +67,7 @@ async function checkActionStatus(context: IActionContext, node: ActionTreeItem, 
 
                 const client: Octokit = await createOctokitClient();
                 const workflowRun: ActionsGetWorkflowRunResponseData = (await client.actions.getWorkflowRun({ owner: node.data.repository.owner.login, repo: node.data.repository.name, run_id: node.data.id })).data;
-                if (workflowRun.status === 'completed') {
+                if (ensureStatus(workflowRun) === 'completed') {
                     const actionCompleted: string = localize('actionCompleted', 'Action "{0}" has completed with the conclusion "{1}".', node.data.id, workflowRun.conclusion);
                     ext.outputChannel.appendLog(actionCompleted);
                     window.showInformationMessage(actionCompleted);

--- a/src/commands/github/actionCommands.ts
+++ b/src/commands/github/actionCommands.ts
@@ -25,7 +25,7 @@ export async function rerunAction(context: IActionContext, node?: ActionTreeItem
     const client: Octokit = await createOctokitClient();
     await client.actions.reRunWorkflow({ owner: node.data.repository.owner.login, repo: node.data.repository.name, run_id: node.data.id });
     await node.refresh(); // need to refresh to update the data
-    await checkActionStatus(context, node, 'rerun');
+    await checkActionStatus(context, node);
 }
 
 export async function cancelAction(context: IActionContext, node?: ActionTreeItem): Promise<void> {
@@ -39,10 +39,10 @@ export async function cancelAction(context: IActionContext, node?: ActionTreeIte
     const client: Octokit = await createOctokitClient();
     await client.actions.cancelWorkflowRun({ owner: node.data.repository.owner.login, repo: node.data.repository.name, run_id: node.data.id });
     await node.refresh(); // need to refresh to update the data
-    await checkActionStatus(context, node, 'cancel');
+    await checkActionStatus(context, node);
 }
 
-async function checkActionStatus(context: IActionContext, node: ActionTreeItem, action: 'rerun' | 'cancel'): Promise<void> {
+async function checkActionStatus(context: IActionContext, node: ActionTreeItem): Promise<void> {
     const startTime: number = Date.now();
     const client: Octokit = await createOctokitClient();
     const pollingOperation: () => Promise<boolean> = async () => {
@@ -54,7 +54,6 @@ async function checkActionStatus(context: IActionContext, node: ActionTreeItem, 
             await node.refresh();
             context.telemetry.properties.secToReport = String((Date.now() - startTime) / 1000);
             context.telemetry.properties.conclusion = workflowRun.conclusion;
-            context.telemetry.properties.action = action;
             return true;
         }
 

--- a/src/commands/github/actionCommands.ts
+++ b/src/commands/github/actionCommands.ts
@@ -60,7 +60,7 @@ async function checkActionStatus(context: IActionContext, node: ActionTreeItem):
         return false;
     };
 
-    if (!await pollAsyncOperation(pollingOperation, 15, 20 * 60, String(node.data.id))) {
+    if (!await pollAsyncOperation(pollingOperation, 15, 20 * 60, node.fullId)) {
         const operationTimedOut: string = localize('timedOut', 'The action "{0}" is still running.  Check "{1}" for its status', node.data.id, node.data.html_url);
         ext.outputChannel.appendLog(operationTimedOut);
         window.showInformationMessage(operationTimedOut);

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -49,7 +49,7 @@ function convertConclusionToVerb(conclusion: Conclusion): string {
     }
 }
 
-function ensureStatus(data: { status: string }): Status {
+export function ensureStatus(data: { status: string }): Status {
     if (Object.values(Status).includes(<Status>data.status)) {
         return <Status>data.status;
     } else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/172
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/262

I think that this solution mitigates one of our concerns about polling before which was refreshing the tree or tree node was a waste of resources and also distracting.  Also because the frequency of polling gets incrementally longer, if it's a long-running build, it shouldn't impact the user too badly.

Plus I don't see people rerunning too many actions at once anyway. 