### PR TITLE
Changing references to App Artifact to Output Location

### DIFF
--- a/package.json
+++ b/package.json
@@ -416,7 +416,8 @@
                     "staticWebApps.appArtifactSubpath": {
                         "scope": "resource",
                         "type": "string",
-                        "description": "%staticWebApps.appArtifactSubpath%"
+                        "description": "%staticWebApps.appArtifactSubpath%",
+                        "deprecationMessage": "%staticWebApps.appArtifactSubpathDeprecated%"
                     },
                     "staticWebApps.outputLocationSubpath": {
                         "scope": "resource",
@@ -466,7 +467,7 @@
         "webpack-cli": "^3.3.12"
     },
     "dependencies": {
-        "@azure/arm-appservice": "^6.0.0",
+        "@azure/arm-appservice": "^6.1.0",
         "@azure/ms-rest-js": "^2.0.8",
         "@octokit/rest": "^18.0.3",
         "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -417,6 +417,11 @@
                         "scope": "resource",
                         "type": "string",
                         "description": "%staticWebApps.appArtifactSubpath%"
+                    },
+                    "staticWebApps.outputLocationSubpath": {
+                        "scope": "resource",
+                        "type": "string",
+                        "description": "%staticWebApps.outputLocationSubpath%"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -467,7 +467,7 @@
         "webpack-cli": "^3.3.12"
     },
     "dependencies": {
-        "@azure/arm-appservice": "^6.1.0",
+        "@azure/arm-appservice": "^6.0.0",
         "@azure/ms-rest-js": "^2.0.8",
         "@octokit/rest": "^18.0.3",
         "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -419,10 +419,10 @@
                         "description": "%staticWebApps.appArtifactSubpath%",
                         "deprecationMessage": "%staticWebApps.appArtifactSubpathDeprecated%"
                     },
-                    "staticWebApps.outputLocationSubpath": {
+                    "staticWebApps.outputSubpath": {
                         "scope": "resource",
                         "type": "string",
-                        "description": "%staticWebApps.outputLocationSubpath%"
+                        "description": "%staticWebApps.outputSubpath%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -28,7 +28,7 @@
     "staticWebApps.appSubpath": "The default value for the location of the application code prompt",
     "staticWebApps.apiSubpath": "The default value for the location of your Azure Functions code",
     "staticWebApps.appArtifactSubpath": "The default value for the location of your build output relative to your application code location",
-    "staticWebApps.appArtifactSubpathDeprecated": "Deprecated.  Use the staticWebApps.outputLocationSubpath setting rather than this one.",
+    "staticWebApps.appArtifactSubpathDeprecated": "Deprecated.  Use the staticWebApps.outputLocationSubpath setting instead.",
     "staticWebApps.action.rerun": "Rerun Action...",
     "staticWebApps.action.cancel": "Cancel Action...",
     "staticWebApps.showDocumentation": "Documentation",

--- a/package.nls.json
+++ b/package.nls.json
@@ -28,10 +28,10 @@
     "staticWebApps.appSubpath": "The default value for the location of the application code prompt",
     "staticWebApps.apiSubpath": "The default value for the location of your Azure Functions code",
     "staticWebApps.appArtifactSubpath": "The default value for the location of your build output relative to your application code location",
-    "staticWebApps.appArtifactSubpathDeprecated": "Deprecated.  Use the staticWebApps.outputLocationSubpath setting instead.",
+    "staticWebApps.appArtifactSubpathDeprecated": "Deprecated.  Use the staticWebApps.outputSubpath setting instead.",
     "staticWebApps.action.rerun": "Rerun Action...",
     "staticWebApps.action.cancel": "Cancel Action...",
     "staticWebApps.showDocumentation": "Documentation",
     "staticWebApps.openYAMLConfigFile": "Edit Configuration...",
-    "staticWebApps.outputLocationSubpath": "The default value for the location of your build output relative to your application code location"
+    "staticWebApps.outputSubpath": "The default value for the location of your build output relative to your application code location"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -28,8 +28,10 @@
     "staticWebApps.appSubpath": "The default value for the location of the application code prompt",
     "staticWebApps.apiSubpath": "The default value for the location of your Azure Functions code",
     "staticWebApps.appArtifactSubpath": "The default value for the location of your build output relative to your application code location",
+    "staticWebApps.appArtifactSubpathDeprecated": "Deprecated.  Use the staticWebApps.outputLocationSubpath setting rather than this one.",
     "staticWebApps.action.rerun": "Rerun Action...",
     "staticWebApps.action.cancel": "Cancel Action...",
     "staticWebApps.showDocumentation": "Documentation",
-    "staticWebApps.openYAMLConfigFile": "Edit Configuration..."
+    "staticWebApps.openYAMLConfigFile": "Edit Configuration...",
+    "staticWebApps.outputLocationSubpath": "The default value for the location of your build output relative to your application code location"
 }

--- a/src/buildPresets/IBuildPreset.ts
+++ b/src/buildPresets/IBuildPreset.ts
@@ -12,5 +12,5 @@ export interface IBuildPreset {
     displayName: string;
     appLocation: string;
     apiLocation: string;
-    outputLocationSubpath: string;
+    outputLocation: string;
 }

--- a/src/buildPresets/IBuildPreset.ts
+++ b/src/buildPresets/IBuildPreset.ts
@@ -12,5 +12,5 @@ export interface IBuildPreset {
     displayName: string;
     appLocation: string;
     apiLocation: string;
-    appArtifactLocation: string;
+    outputLocationSubpath: string;
 }

--- a/src/buildPresets/buildPresets.ts
+++ b/src/buildPresets/buildPresets.ts
@@ -12,35 +12,35 @@ export const buildPresets: IBuildPreset[] = [
         displayName: 'Angular',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocationSubpath: 'dist'
+        outputLocation: 'dist'
     },
     {
         id: 'react',
         displayName: 'React',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocationSubpath: 'build'
+        outputLocation: 'build'
     },
     {
         id: 'svelte',
         displayName: 'Svelte',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocationSubpath: 'public'
+        outputLocation: 'public'
     },
     {
         id: 'vuejs',
         displayName: 'Vue.js',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocationSubpath: 'dist'
+        outputLocation: 'dist'
     },
     {
         id: 'blazor',
         displayName: 'Blazor',
         appLocation: 'Client',
         apiLocation: 'Api',
-        outputLocationSubpath: 'wwwroot'
+        outputLocation: 'wwwroot'
     },
 
     {
@@ -48,20 +48,20 @@ export const buildPresets: IBuildPreset[] = [
         displayName: 'Gatsby',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocationSubpath: 'public'
+        outputLocation: 'public'
     },
     {
         id: 'hugo',
         displayName: 'Hugo',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocationSubpath: 'public'
+        outputLocation: 'public'
     },
     {
         id: 'vuepress',
         displayName: 'VuePress',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocationSubpath: '.vuepress/dist'
+        outputLocation: '.vuepress/dist'
     }
 ];

--- a/src/buildPresets/buildPresets.ts
+++ b/src/buildPresets/buildPresets.ts
@@ -12,35 +12,35 @@ export const buildPresets: IBuildPreset[] = [
         displayName: 'Angular',
         appLocation: '/',
         apiLocation: 'api',
-        appArtifactLocation: 'dist'
+        outputLocationSubpath: 'dist'
     },
     {
         id: 'react',
         displayName: 'React',
         appLocation: '/',
         apiLocation: 'api',
-        appArtifactLocation: 'build'
+        outputLocationSubpath: 'build'
     },
     {
         id: 'svelte',
         displayName: 'Svelte',
         appLocation: '/',
         apiLocation: 'api',
-        appArtifactLocation: 'public'
+        outputLocationSubpath: 'public'
     },
     {
         id: 'vuejs',
         displayName: 'Vue.js',
         appLocation: '/',
         apiLocation: 'api',
-        appArtifactLocation: 'dist'
+        outputLocationSubpath: 'dist'
     },
     {
         id: 'blazor',
         displayName: 'Blazor',
         appLocation: 'Client',
         apiLocation: 'Api',
-        appArtifactLocation: 'wwwroot'
+        outputLocationSubpath: 'wwwroot'
     },
 
     {
@@ -48,20 +48,20 @@ export const buildPresets: IBuildPreset[] = [
         displayName: 'Gatsby',
         appLocation: '/',
         apiLocation: 'api',
-        appArtifactLocation: 'public'
+        outputLocationSubpath: 'public'
     },
     {
         id: 'hugo',
         displayName: 'Hugo',
         appLocation: '/',
         apiLocation: 'api',
-        appArtifactLocation: 'public'
+        outputLocationSubpath: 'public'
     },
     {
         id: 'vuepress',
         displayName: 'VuePress',
         appLocation: '/',
         apiLocation: 'api',
-        appArtifactLocation: '.vuepress/dist'
+        outputLocationSubpath: '.vuepress/dist'
     }
 ];

--- a/src/commands/createStaticWebApp/BuildPresetListStep.ts
+++ b/src/commands/createStaticWebApp/BuildPresetListStep.ts
@@ -12,7 +12,7 @@ import { openUrl } from '../../utils/openUrl';
 import { ApiLocationStep } from './ApiLocationStep';
 import { AppLocationStep } from './AppLocationStep';
 import { IStaticWebAppWizardContext } from './IStaticWebAppWizardContext';
-import { AppArtifactLocationStep } from './OutputLocationStep';
+import { OutputLocationStep } from './OutputLocationStep';
 
 export class BuildPresetListStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
 
@@ -34,7 +34,7 @@ export class BuildPresetListStep extends AzureWizardPromptStep<IStaticWebAppWiza
         if (pick.data) {
             context.appLocation = pick.data.appLocation;
             context.apiLocation = pick.data.apiLocation;
-            context.appArtifactLocation = pick.data.appArtifactLocation;
+            context.outputLocation = pick.data.outputLocation;
         }
 
     }
@@ -45,7 +45,7 @@ export class BuildPresetListStep extends AzureWizardPromptStep<IStaticWebAppWiza
 
     public async getSubWizard(context: IStaticWebAppWizardContext): Promise<IWizardOptions<IStaticWebAppWizardContext> | undefined> {
         if (!context.appLocation) {
-            return { promptSteps: [new AppLocationStep(), new ApiLocationStep(), new AppArtifactLocationStep()] };
+            return { promptSteps: [new AppLocationStep(), new ApiLocationStep(), new OutputLocationStep()] };
         } else {
             return undefined;
         }

--- a/src/commands/createStaticWebApp/BuildPresetListStep.ts
+++ b/src/commands/createStaticWebApp/BuildPresetListStep.ts
@@ -10,9 +10,9 @@ import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
 import { openUrl } from '../../utils/openUrl';
 import { ApiLocationStep } from './ApiLocationStep';
-import { AppArtifactLocationStep } from './AppArtifactLocationStep';
 import { AppLocationStep } from './AppLocationStep';
 import { IStaticWebAppWizardContext } from './IStaticWebAppWizardContext';
+import { AppArtifactLocationStep } from './OutputLocationStep';
 
 export class BuildPresetListStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
 

--- a/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
+++ b/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
@@ -28,7 +28,7 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext,
 
     appLocation?: string;
     apiLocation?: string;
-    appArtifactLocation?: string;
+    outputLocation?: string;
 
     // created when the wizard is done executing
     staticWebApp?: WebSiteManagementModels.StaticSiteARMResource;

--- a/src/commands/createStaticWebApp/OutputLocationStep.ts
+++ b/src/commands/createStaticWebApp/OutputLocationStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
-import { appArtifactSubpathSetting, outputLocationSubpathSetting } from "../../constants";
+import { appArtifactSubpathSetting, outputSubpathSetting } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
 import { getWorkspaceSetting } from "../../utils/settingsUtils";
@@ -15,7 +15,7 @@ export class OutputLocationStep extends AzureWizardPromptStep<IStaticWebAppWizar
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
         const defaultLocation: string = 'build';
         wizardContext.outputLocation = (await ext.ui.showInputBox({
-            value: getWorkspaceSetting(outputLocationSubpathSetting, wizardContext.fsPath) || getWorkspaceSetting(appArtifactSubpathSetting, wizardContext.fsPath) || defaultLocation,
+            value: getWorkspaceSetting(outputSubpathSetting, wizardContext.fsPath) || getWorkspaceSetting(appArtifactSubpathSetting, wizardContext.fsPath) || defaultLocation,
             prompt: localize('publishLocation', "Enter the path of your build output relative to your app's location. For example, setting a value of 'build' when your app location is set to 'app' will cause the content at 'app/build' to be served.")
         })).trim();
         addLocationTelemetry(wizardContext, 'outputLocation', defaultLocation);

--- a/src/commands/createStaticWebApp/OutputLocationStep.ts
+++ b/src/commands/createStaticWebApp/OutputLocationStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
-import { appArtifactSubpathSetting } from "../../constants";
+import { appArtifactSubpathSetting, outputLocationSubpathSetting } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
 import { getWorkspaceSetting } from "../../utils/settingsUtils";
@@ -14,15 +14,15 @@ import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 export class OutputLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
         const defaultLocation: string = 'build';
-        wizardContext.appArtifactLocation = (await ext.ui.showInputBox({
-            value: getWorkspaceSetting(appArtifactSubpathSetting, wizardContext.fsPath) || defaultLocation,
+        wizardContext.outputLocation = (await ext.ui.showInputBox({
+            value: getWorkspaceSetting(outputLocationSubpathSetting, wizardContext.fsPath) || getWorkspaceSetting(appArtifactSubpathSetting, wizardContext.fsPath) || defaultLocation,
             prompt: localize('publishLocation', "Enter the path of your build output relative to your app's location. For example, setting a value of 'build' when your app location is set to 'app' will cause the content at 'app/build' to be served.")
         })).trim();
-        addLocationTelemetry(wizardContext, 'appArtifactLocation', defaultLocation);
+        addLocationTelemetry(wizardContext, 'outputLocation', defaultLocation);
     }
 
     public shouldPrompt(wizardContext: IStaticWebAppWizardContext): boolean {
-        return !wizardContext.appArtifactLocation;
+        return !wizardContext.outputLocation;
     }
 
 }

--- a/src/commands/createStaticWebApp/OutputLocationStep.ts
+++ b/src/commands/createStaticWebApp/OutputLocationStep.ts
@@ -11,7 +11,7 @@ import { getWorkspaceSetting } from "../../utils/settingsUtils";
 import { addLocationTelemetry } from "./addLocationTelemetry";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
-export class AppArtifactLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
+export class OutputLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
         const defaultLocation: string = 'build';
         wizardContext.appArtifactLocation = (await ext.ui.showInputBox({

--- a/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
@@ -23,7 +23,7 @@ export class StaticWebAppCreateStep extends AzureWizardExecuteStep<IStaticWebApp
             buildProperties: {
                 appLocation: wizardContext.appLocation,
                 apiLocation: wizardContext.apiLocation,
-                outputLocation: wizardContext.outputLocation
+                appArtifactLocation: wizardContext.outputLocation
             },
             sku: { name: 'Free', tier: 'Free' },
             location: nonNullValueAndProp(wizardContext.location, 'name')

--- a/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
@@ -23,7 +23,7 @@ export class StaticWebAppCreateStep extends AzureWizardExecuteStep<IStaticWebApp
             buildProperties: {
                 appLocation: wizardContext.appLocation,
                 apiLocation: wizardContext.apiLocation,
-                appArtifactLocation: wizardContext.appArtifactLocation
+                outputLocation: wizardContext.outputLocation
             },
             sku: { name: 'Free', tier: 'Free' },
             location: nonNullValueAndProp(wizardContext.location, 'name')

--- a/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
@@ -20,6 +20,7 @@ export class StaticWebAppCreateStep extends AzureWizardExecuteStep<IStaticWebApp
             repositoryUrl: wizardContext.repoHtmlUrl,
             branch: wizardContext.branchData?.name,
             repositoryToken: wizardContext.accessToken,
+            // The SDK hasn't updated to reflect the outputLocation property and platform will continue supporting appArtifactLocation, but will update as soon as available
             buildProperties: {
                 appLocation: wizardContext.appLocation,
                 apiLocation: wizardContext.apiLocation,

--- a/src/commands/createStaticWebApp/addLocationTelemetry.ts
+++ b/src/commands/createStaticWebApp/addLocationTelemetry.ts
@@ -5,7 +5,7 @@
 
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
-export function addLocationTelemetry(wizardContext: IStaticWebAppWizardContext, key: 'appLocation' | 'apiLocation' | 'appArtifactLocation', defaultValue: string): void {
+export function addLocationTelemetry(wizardContext: IStaticWebAppWizardContext, key: 'appLocation' | 'apiLocation' | 'outputLocation', defaultValue: string): void {
     const value: string | undefined = wizardContext[key];
     let telemValue: string;
     if (value === undefined) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,4 @@ export const productionEnvironmentName: string = 'Production';
 export const appSubpathSetting: string = 'appSubpath';
 export const apiSubpathSetting: string = 'apiSubpath';
 export const appArtifactSubpathSetting: string = 'appArtifactSubpath';
+export const outputLocationSubpathSetting: string = 'outputLocationSubpath';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,4 +12,4 @@ export const productionEnvironmentName: string = 'Production';
 export const appSubpathSetting: string = 'appSubpath';
 export const apiSubpathSetting: string = 'apiSubpath';
 export const appArtifactSubpathSetting: string = 'appArtifactSubpath';
-export const outputLocationSubpathSetting: string = 'outputLocationSubpath';
+export const outputSubpathSetting: string = 'outputSubpath';

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -14,7 +14,7 @@ import { GitHubRepoListStep } from '../commands/createStaticWebApp/GitHubRepoLis
 import { IStaticWebAppWizardContext } from '../commands/createStaticWebApp/IStaticWebAppWizardContext';
 import { StaticWebAppCreateStep } from '../commands/createStaticWebApp/StaticWebAppCreateStep';
 import { StaticWebAppNameStep } from '../commands/createStaticWebApp/StaticWebAppNameStep';
-import { apiSubpathSetting, appArtifactSubpathSetting, appSubpathSetting } from '../constants';
+import { apiSubpathSetting, appSubpathSetting, outputLocationSubpathSetting } from '../constants';
 import { getGitHubAccessToken, tryGetRemote } from '../utils/gitHubUtils';
 import { localize } from '../utils/localize';
 import { nonNullProp } from '../utils/nonNull';
@@ -110,7 +110,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         if (wizardContext.fsPath && gotRemote) {
             await updateWorkspaceSetting(appSubpathSetting, wizardContext.appLocation, wizardContext.fsPath);
             await updateWorkspaceSetting(apiSubpathSetting, wizardContext.apiLocation, wizardContext.fsPath);
-            await updateWorkspaceSetting(appArtifactSubpathSetting, wizardContext.appArtifactLocation, wizardContext.fsPath);
+            await updateWorkspaceSetting(outputLocationSubpathSetting, wizardContext.outputLocation, wizardContext.fsPath);
         }
 
         return new StaticWebAppTreeItem(this, nonNullProp(wizardContext, 'staticWebApp'));

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -14,7 +14,7 @@ import { GitHubRepoListStep } from '../commands/createStaticWebApp/GitHubRepoLis
 import { IStaticWebAppWizardContext } from '../commands/createStaticWebApp/IStaticWebAppWizardContext';
 import { StaticWebAppCreateStep } from '../commands/createStaticWebApp/StaticWebAppCreateStep';
 import { StaticWebAppNameStep } from '../commands/createStaticWebApp/StaticWebAppNameStep';
-import { apiSubpathSetting, appSubpathSetting, outputLocationSubpathSetting } from '../constants';
+import { apiSubpathSetting, appSubpathSetting, outputSubpathSetting } from '../constants';
 import { getGitHubAccessToken, tryGetRemote } from '../utils/gitHubUtils';
 import { localize } from '../utils/localize';
 import { nonNullProp } from '../utils/nonNull';
@@ -110,7 +110,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         if (wizardContext.fsPath && gotRemote) {
             await updateWorkspaceSetting(appSubpathSetting, wizardContext.appLocation, wizardContext.fsPath);
             await updateWorkspaceSetting(apiSubpathSetting, wizardContext.apiLocation, wizardContext.fsPath);
-            await updateWorkspaceSetting(outputLocationSubpathSetting, wizardContext.outputLocation, wizardContext.fsPath);
+            await updateWorkspaceSetting(outputSubpathSetting, wizardContext.outputLocation, wizardContext.fsPath);
         }
 
         return new StaticWebAppTreeItem(this, nonNullProp(wizardContext, 'staticWebApp'));


### PR DESCRIPTION
As per Mitch's offline email, the yml is now constructed with output_location rather than app_artifact_location so just changing it within the extension to be consistent.  The SDK hasn't updated to reflect this change and they'll keep supporting appArtifactLocation, so we should be good to keep that as-is for now.