### PR TITLE
Action$ to Action so that context menu item for view property shows up

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
                 },
                 {
                     "command": "staticWebApps.viewProperties",
-                    "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment|Action$|Job|Step$)/",
+                    "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment|Action|Job|Step$)/",
                     "group": "9@1"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
                 },
                 {
                     "command": "staticWebApps.viewProperties",
-                    "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment|Action|Job|Step$)/",
+                    "when": "view == staticWebApps && viewItem =~ /azureStatic(WebApp|Environment|Action[^s]|Job|Step$)/",
                     "group": "9@1"
                 },
                 {


### PR DESCRIPTION
When I changed the context value of ActionTreeItems, the view properties command wasn't showing up for Actions nodes.