### PR TITLE
Add experimental service from 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - "Report an Issue" button was removed from errors. Use the "Help and Feedback" view or command palette instead
 - Minimum version of VS Code is now 1.53.0
 
+## 0.5.1 - 2021-04-12
+
+### Added
+- Experimental framework to test incremental changes
+
 ## 0.5.0 - 2020-12-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "vscode-azurestaticwebapps",
-    "version": "0.5.1-alpha",
+    "version": "0.5.2-alpha",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.5.1-alpha",
+            "version": "0.5.2-alpha",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurestaticwebapps",
     "displayName": "Azure Static Web Apps (Preview)",
     "description": "%staticWebApps.description%",
-    "version": "0.5.1-alpha",
+    "version": "0.5.2-alpha",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-staticwebapps.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode';
 import { registerAppServiceExtensionVariables } from 'vscode-azureappservice';
-import { AzExtTreeDataProvider, AzureUserInput, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, IActionContext, registerUIExtensionVariables } from 'vscode-azureextensionui';
+import { AzExtTreeDataProvider, AzureUserInput, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, createExperimentationService, IActionContext, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { AzureExtensionApi, AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { revealTreeItem } from './commands/api/revealTreeItem';
 import { registerCommands } from './commands/registerCommands';
@@ -35,6 +35,8 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         context.subscriptions.push(ext.treeView);
 
         registerCommands();
+
+        ext.experimentationService = await createExperimentationService(context);
     });
 
     return createApiProvider([<AzureExtensionApi>{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     registerUIExtensionVariables(ext);
     registerAppServiceExtensionVariables(ext);
 
-    await callWithTelemetryAndErrorHandling('staticWebApps.activate', (activateContext: IActionContext) => {
+    await callWithTelemetryAndErrorHandling('staticWebApps.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
 

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ExtensionContext, TreeView } from "vscode";
-import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtOutputChannel, IAzureUserInput } from "vscode-azureextensionui";
+import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtOutputChannel, IAzureUserInput, IExperimentationServiceAdapter } from "vscode-azureextensionui";
 
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
@@ -17,4 +17,5 @@ export namespace ext {
     export let ui: IAzureUserInput;
     export let ignoreBundle: boolean | undefined;
     export const prefix: string = 'staticWebApps';
+    export let experimentationService: IExperimentationServiceAdapter;
 }


### PR DESCRIPTION
Fixes #328 

Retroactively adding the 0.5.1 release changes.