### PR TITLE
Throw better errors if SWA isn't linked to GitHub

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,3 +21,5 @@ export const enableLocalProjectView: string = 'enableLocalProjectView';
 export const configFileName: string = 'staticwebapp.config.json';
 
 export const showActionsMsg: MessageItem = { title: localize('openActions', 'Open Actions in GitHub') };
+
+export const onlyGitHubSupported: string = localize('onlyGitHubSupported', 'Only Static Web Apps linked to GitHub are supported at this time.');

--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -8,7 +8,7 @@ import { ProgressLocation, ThemeIcon, window } from "vscode";
 import { AppSettingsTreeItem, AppSettingTreeItem } from "vscode-azureappservice";
 import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { AppSettingsClient } from "../commands/appSettings/AppSettingsClient";
-import { enableLocalProjectView, productionEnvironmentName } from "../constants";
+import { enableLocalProjectView, onlyGitHubSupported, productionEnvironmentName } from "../constants";
 import { ext } from "../extensionVariables";
 import { createWebSiteClient } from "../utils/azureClients";
 import { pollAzureAsyncOperation } from "../utils/azureUtils";
@@ -61,7 +61,12 @@ export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureRe
         this.buildId = nonNullProp(this.data, 'buildId');
 
         this.repositoryUrl = this.parent.repositoryUrl;
-        this.branch = nonNullProp(this.data, 'sourceBranch');
+
+        if (this.data.sourceBranch) {
+            this.branch = this.data.sourceBranch;
+        } else {
+            throw new Error(onlyGitHubSupported);
+        }
 
         this.isProduction = this.buildId === 'default';
 

--- a/src/tree/StaticWebAppTreeItem.ts
+++ b/src/tree/StaticWebAppTreeItem.ts
@@ -5,7 +5,7 @@
 
 import { WebSiteManagementClient, WebSiteManagementModels } from "@azure/arm-appservice";
 import { ProgressLocation, window } from "vscode";
-import { AzExtTreeItem, AzureParentTreeItem, IActionContext, IParsedError, parseError, TreeItemIconPath } from "vscode-azureextensionui";
+import { AzExtTreeItem, AzureParentTreeItem, IActionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { onlyGitHubSupported, productionEnvironmentName } from '../constants';
 import { ext } from "../extensionVariables";
 import { createWebSiteClient } from "../utils/azureClients";
@@ -39,7 +39,13 @@ export class StaticWebAppTreeItem extends AzureParentTreeItem implements IAzureR
         this.id = nonNullProp(this.data, 'id');
         this.resourceGroup = getResourceGroupFromId(this.id);
         this.label = this.name;
-        this.repositoryUrl = nonNullProp(this.data, 'repositoryUrl');
+
+        if (this.data.repositoryUrl) {
+            this.repositoryUrl = this.data.repositoryUrl;
+        } else {
+            throw new Error(onlyGitHubSupported);
+        }
+
         this.branch = nonNullProp(this.data, 'branch');
         this.defaultHostname = nonNullProp(this.data, 'defaultHostname');
     }
@@ -62,15 +68,7 @@ export class StaticWebAppTreeItem extends AzureParentTreeItem implements IAzureR
             envs,
             'invalidStaticEnvironment',
             async (env: WebSiteManagementModels.StaticSiteBuildARMResource) => {
-                try {
-                    return await EnvironmentTreeItem.createEnvironmentTreeItem(context, this, env);
-                } catch (error) {
-                    const parsedError: IParsedError = parseError(error);
-                    if (/(null|undefined).*sourceBranch/.test(parsedError.message)) {
-                        throw new Error(onlyGitHubSupported);
-                    }
-                    throw error;
-                }
+                return await EnvironmentTreeItem.createEnvironmentTreeItem(context, this, env);
             },
             env => env.buildId
         );

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -14,7 +14,7 @@ import { IStaticWebAppWizardContext } from '../commands/createStaticWebApp/IStat
 import { OutputLocationStep } from '../commands/createStaticWebApp/OutputLocationStep';
 import { StaticWebAppCreateStep } from '../commands/createStaticWebApp/StaticWebAppCreateStep';
 import { StaticWebAppNameStep } from '../commands/createStaticWebApp/StaticWebAppNameStep';
-import { apiSubpathSetting, appSubpathSetting, outputSubpathSetting } from '../constants';
+import { apiSubpathSetting, appSubpathSetting, onlyGitHubSupported, outputSubpathSetting } from '../constants';
 import { createWebSiteClient } from '../utils/azureClients';
 import { getGitHubAccessToken, tryGetRemote } from '../utils/gitHubUtils';
 import { localize } from '../utils/localize';
@@ -46,7 +46,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
                 } catch (error) {
                     const parsedError: IParsedError = parseError(error);
                     if (/(null|undefined).*repositoryUrl/.test(parsedError.message)) {
-                        throw new Error(localize('onlySupportGitHub', 'Only Static Web Apps linked to GitHub are supported at this time.'));
+                        throw new Error(onlyGitHubSupported);
                     }
                     throw error;
                 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-appservice';
-import { AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, ICreateChildImplContext, IParsedError, LocationListStep, parseError, ResourceGroupCreateStep, ResourceGroupListStep, SubscriptionTreeItemBase, VerifyProvidersStep } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, ICreateChildImplContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, SubscriptionTreeItemBase, VerifyProvidersStep } from 'vscode-azureextensionui';
 import { addWorkspaceTelemetry } from '../commands/createStaticWebApp/addWorkspaceTelemetry';
 import { ApiLocationStep } from '../commands/createStaticWebApp/ApiLocationStep';
 import { AppLocationStep } from '../commands/createStaticWebApp/AppLocationStep';
@@ -14,7 +14,7 @@ import { IStaticWebAppWizardContext } from '../commands/createStaticWebApp/IStat
 import { OutputLocationStep } from '../commands/createStaticWebApp/OutputLocationStep';
 import { StaticWebAppCreateStep } from '../commands/createStaticWebApp/StaticWebAppCreateStep';
 import { StaticWebAppNameStep } from '../commands/createStaticWebApp/StaticWebAppNameStep';
-import { apiSubpathSetting, appSubpathSetting, onlyGitHubSupported, outputSubpathSetting } from '../constants';
+import { apiSubpathSetting, appSubpathSetting, outputSubpathSetting } from '../constants';
 import { createWebSiteClient } from '../utils/azureClients';
 import { getGitHubAccessToken, tryGetRemote } from '../utils/gitHubUtils';
 import { localize } from '../utils/localize';
@@ -40,17 +40,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         return await this.createTreeItemsWithErrorHandling(
             staticWebApps,
             'invalidStaticWebApp',
-            ss => {
-                try {
-                    return new StaticWebAppTreeItem(this, ss);
-                } catch (error) {
-                    const parsedError: IParsedError = parseError(error);
-                    if (/(null|undefined).*repositoryUrl/.test(parsedError.message)) {
-                        throw new Error(onlyGitHubSupported);
-                    }
-                    throw error;
-                }
-            },
+            ss => new StaticWebAppTreeItem(this, ss),
             ss => ss.name
         );
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/319

| Old | New |
|-|-|
|![Screen Shot 2021-04-27 at 1 53 35 PM](https://user-images.githubusercontent.com/22795803/116311533-343c5400-a760-11eb-9589-a78b3a3cc22a.png)|![Screen Shot 2021-04-27 at 1 52 58 PM](https://user-images.githubusercontent.com/22795803/116311542-36061780-a760-11eb-8ddc-b25968b1b32b.png)|

The first SWA in this example has been linked to Azure DevOps so the SWA node loads fine but the environment doesn't.
The second SWA hasn't been linked to any version control.