### PR TITLE
Refactor some gitHub vs git functions

### DIFF
--- a/src/commands/createRepo/RemoteShortnameStep.ts
+++ b/src/commands/createRepo/RemoteShortnameStep.ts
@@ -7,7 +7,7 @@ import { basename } from 'path';
 import { AzureWizardPromptStep } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { cpUtils } from '../../utils/cpUtils';
-import { remoteShortnameExists } from '../../utils/gitHubUtils';
+import { remoteShortnameExists } from '../../utils/gitUtils';
 import { localize } from '../../utils/localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { IStaticWebAppWizardContext } from '../createStaticWebApp/IStaticWebAppWizardContext';

--- a/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
@@ -5,7 +5,7 @@
 
 import { AzureNameStep, IAzureNamingRules } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
-import { getRepoFullname } from "../../utils/gitHubUtils";
+import { getRepoFullname } from "../../utils/gitUtils";
 import { localize } from "../../utils/localize";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 

--- a/src/commands/createStaticWebApp/postCreateStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/postCreateStaticWebApp.ts
@@ -13,7 +13,7 @@ import { ActionTreeItem } from "../../tree/ActionTreeItem";
 import { EnvironmentTreeItem } from "../../tree/EnvironmentTreeItem";
 import { StaticWebAppTreeItem } from "../../tree/StaticWebAppTreeItem";
 import { delay } from "../../utils/delay";
-import { getRepoFullname } from "../../utils/gitHubUtils";
+import { getRepoFullname } from "../../utils/gitUtils";
 import { localize } from "../../utils/localize";
 import { nonNullValue } from "../../utils/nonNull";
 import { openUrl } from "../../utils/openUrl";

--- a/src/commands/createStaticWebApp/setWorkspaceContexts.ts
+++ b/src/commands/createStaticWebApp/setWorkspaceContexts.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import { join } from "path";
 import { IActionContext } from "vscode-azureextensionui";
-import { remoteShortnameExists } from "../../utils/gitHubUtils";
+import { remoteShortnameExists } from "../../utils/gitUtils";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
 export async function setWorkspaceContexts(wizardContext: IActionContext & Partial<IStaticWebAppWizardContext>, fsPath: string): Promise<void> {

--- a/src/tree/ActionTreeItem.ts
+++ b/src/tree/ActionTreeItem.ts
@@ -9,7 +9,7 @@ import { AzExtTreeItem, AzureParentTreeItem, IActionContext, TreeItemIconPath } 
 import { createOctokitClient } from '../commands/github/createOctokitClient';
 import { ActionsGetWorkflowRunResponseData, ActionsListJobsForWorkflowRunResponseData } from '../gitHubTypings';
 import { ensureStatus, getActionIconPath } from '../utils/actionUtils';
-import { getRepoFullname } from '../utils/gitHubUtils';
+import { getRepoFullname } from '../utils/gitUtils';
 import { ActionsTreeItem } from "./ActionsTreeItem";
 import { IAzureResourceTreeItem } from './IAzureResourceTreeItem';
 import { JobTreeItem } from './JobTreeItem';

--- a/src/tree/ActionsTreeItem.ts
+++ b/src/tree/ActionsTreeItem.ts
@@ -9,7 +9,7 @@ import { ThemeIcon } from "vscode";
 import { AzExtTreeItem, AzureParentTreeItem, IActionContext, TreeItemIconPath } from "vscode-azureextensionui";
 import { createOctokitClient } from "../commands/github/createOctokitClient";
 import { ActionsListWorkflowRunsForRepoResponseData } from "../gitHubTypings";
-import { getRepoFullname } from '../utils/gitHubUtils';
+import { getRepoFullname } from '../utils/gitUtils';
 import { localize } from "../utils/localize";
 import { ActionTreeItem } from './ActionTreeItem';
 import { EnvironmentTreeItem } from "./EnvironmentTreeItem";

--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -12,7 +12,8 @@ import { enableLocalProjectView, onlyGitHubSupported, productionEnvironmentName 
 import { ext } from "../extensionVariables";
 import { createWebSiteClient } from "../utils/azureClients";
 import { pollAzureAsyncOperation } from "../utils/azureUtils";
-import { tryGetLocalBranch, tryGetRepoDataForCreation } from "../utils/gitHubUtils";
+import { tryGetRepoDataForCreation } from "../utils/gitHubUtils";
+import { tryGetLocalBranch } from "../utils/gitUtils";
 import { localize } from "../utils/localize";
 import { nonNullProp } from "../utils/nonNull";
 import { openUrl } from "../utils/openUrl";

--- a/src/tree/JobTreeItem.ts
+++ b/src/tree/JobTreeItem.ts
@@ -8,7 +8,7 @@ import { AzExtTreeItem, AzureParentTreeItem, IActionContext, TreeItemIconPath } 
 import { createOctokitClient } from '../commands/github/createOctokitClient';
 import { ActionsGetJobForWorkflowRunResponseData } from '../gitHubTypings';
 import { getActionDescription, getActionIconPath } from '../utils/actionUtils';
-import { getRepoFullname } from '../utils/gitHubUtils';
+import { getRepoFullname } from '../utils/gitUtils';
 import { ActionTreeItem } from './ActionTreeItem';
 import { IAzureResourceTreeItem } from './IAzureResourceTreeItem';
 import { StepTreeItem } from './StepTreeItem';

--- a/src/tree/StaticWebAppTreeItem.ts
+++ b/src/tree/StaticWebAppTreeItem.ts
@@ -10,7 +10,7 @@ import { onlyGitHubSupported, productionEnvironmentName } from '../constants';
 import { ext } from "../extensionVariables";
 import { createWebSiteClient } from "../utils/azureClients";
 import { getResourceGroupFromId, pollAzureAsyncOperation } from "../utils/azureUtils";
-import { getRepoFullname } from '../utils/gitHubUtils';
+import { getRepoFullname } from '../utils/gitUtils';
 import { localize } from "../utils/localize";
 import { nonNullProp } from "../utils/nonNull";
 import { openUrl } from '../utils/openUrl';

--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -4,17 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Octokit } from '@octokit/rest';
-import { OctokitResponse } from '@octokit/types';
-import * as gitUrlParse from 'git-url-parse';
-import * as git from 'simple-git/promise';
-import { URL } from 'url';
-import { authentication, QuickPickItem } from 'vscode';
+import { authentication } from 'vscode';
 import { IActionContext, IAzureQuickPickItem, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { createOctokitClient } from '../commands/github/createOctokitClient';
 import { ListOrgsForUserData, OrgForAuthenticatedUserData, ReposGetResponseData } from '../gitHubTypings';
-import { getSingleRootFsPath } from './workspaceUtils';
-
-type gitHubLink = { prev?: string; next?: string; last?: string; first?: string };
+import { getRepoFullname, tryGetRemote } from './gitUtils';
 
 /**
  * @param label Property of JSON that will be used as the QuickPicks label
@@ -39,65 +33,6 @@ export function createQuickPickFromJsons<T>(data: T[], label: string): IAzureQui
     return quickPicks;
 }
 
-function parseLinkHeaderToGitHubLinkObject(linkHeader: string): gitHubLink {
-    const linkUrls: string[] = linkHeader.split(', ');
-    const linkMap: gitHubLink = {};
-
-    // link header response is "<https://api.github.com/organizations/6154722/repos?page=2>; rel="prev", <https://api.github.com/organizations/6154722/repos?page=4>; rel="next""
-    const relative: string = 'rel=';
-    for (const url of linkUrls) {
-        linkMap[url.substring(url.indexOf(relative) + relative.length + 1, url.length - 1)] = url.substring(url.indexOf('<') + 1, url.indexOf('>'));
-    }
-    return linkMap;
-}
-
-export interface ICachedQuickPicks<T> {
-    picks: IAzureQuickPickItem<T>[];
-}
-
-export async function getGitHubQuickPicksWithLoadMore<TResult, TParams>(
-    cache: ICachedQuickPicks<TResult>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    gitHubApiCb: (params: TParams) => Promise<OctokitResponse<any>>,
-    params: TParams & { page?: number },
-    labelName: string,
-    timeoutSeconds: number = 10): Promise<IAzureQuickPickItem<TResult | undefined>[]> {
-
-    const timeoutMs: number = timeoutSeconds * 1000;
-    const startTime: number = Date.now();
-    let gitHubQuickPicks: TResult[] = [];
-    do {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const res: OctokitResponse<any> = await gitHubApiCb(params);
-        if (res.headers.link) {
-            // Reference for GitHub REST routes
-            // https://developer.github.com/v3/
-            const linkObject: gitHubLink = parseLinkHeaderToGitHubLinkObject(res.headers.link);
-            const page: string | null | undefined = linkObject.next ? new URL(linkObject.next).searchParams.get('page') : undefined;
-            params.page = page ? Number(page) : undefined;
-        }
-
-        gitHubQuickPicks = gitHubQuickPicks.concat(res.data);
-        if (params.page === undefined) {
-            // if there is no page, that means it has retrieved all of the branches
-            break;
-        }
-    } while (params.page !== undefined && startTime + timeoutMs > Date.now());
-
-    cache.picks = cache.picks.concat(createQuickPickFromJsons(gitHubQuickPicks, labelName));
-    cache.picks.sort((a: QuickPickItem, b: QuickPickItem) => a.label.localeCompare(b.label));
-
-    if (params.page !== undefined) {
-        return (<IAzureQuickPickItem<TResult | undefined>[]>[{
-            label: '$(sync) Load More',
-            suppressPersistence: true,
-            data: undefined
-        }]).concat(cache.picks);
-    } else {
-        return cache.picks;
-    }
-}
-
 export async function getGitHubAccessToken(context: IActionContext): Promise<string> {
     const scopes: string[] = ['repo', 'workflow', 'admin:public_key'];
     try {
@@ -110,22 +45,6 @@ export async function getGitHubAccessToken(context: IActionContext): Promise<str
 
         throw error;
     }
-}
-
-export async function tryGetRemote(localProjectPath?: string): Promise<string | undefined> {
-    let originUrl: string | void | undefined;
-    localProjectPath = localProjectPath || getSingleRootFsPath();
-    // only try to get remote if provided a path or if there's only a single workspace opened
-    if (localProjectPath) {
-        try {
-            const localGit: git.SimpleGit = git(localProjectPath);
-            originUrl = await localGit.remote(['get-url', 'origin']);
-        } catch (err) {
-            // do nothing, remote origin does not exist
-        }
-    }
-
-    return originUrl ? originUrl : undefined;
 }
 
 export async function tryGetReposGetResponseData(context: IActionContext, originUrl: string): Promise<ReposGetResponseData | undefined> {
@@ -155,42 +74,9 @@ export async function tryGetRepoDataForCreation(context: IActionContext, localPr
     }
 
     return undefined;
-
-}
-
-export async function tryGetLocalBranch(): Promise<string | undefined> {
-    try {
-        const localProjectPath: string | undefined = getSingleRootFsPath();
-        if (localProjectPath) {
-            // only try to get branch if there's only a single workspace opened
-            const localGit: git.SimpleGit = git(localProjectPath);
-
-            return (await localGit.branch()).current;
-        }
-    } catch (error) {
-        // an error here should be ignored, it probably means that they don't have git installed
-    }
-    return;
-}
-
-export function getRepoFullname(gitUrl: string): { owner: string; name: string } {
-    const parsedUrl: gitUrlParse.GitUrl = gitUrlParse(gitUrl);
-    return { owner: parsedUrl.owner, name: parsedUrl.name };
 }
 
 export function isUser(orgData: ListOrgsForUserData | OrgForAuthenticatedUserData | undefined): boolean {
     // if there's no orgData, just assume that it's a user (but this shouldn't happen)
     return !!orgData && 'type' in orgData && orgData.type === 'User';
-}
-
-export async function remoteShortnameExists(fsPath: string, remoteName: string): Promise<boolean> {
-    const localGit: git.SimpleGit = git(fsPath);
-    let hasOrigin: boolean = false;
-    try {
-        hasOrigin = !!(await localGit.getRemotes(false)).find(r => { return r.name === remoteName; });
-    } catch (error) {
-        // ignore the error and assume there is no origin
-    }
-
-    return hasOrigin;
 }

--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fse from 'fs-extra';
+import * as gitUrlParse from 'git-url-parse';
+import * as git from 'simple-git/promise';
 import { MessageItem, Uri } from "vscode";
 import { IActionContext } from "vscode-azureextensionui";
 import { IStaticWebAppWizardContext } from "../commands/createStaticWebApp/IStaticWebAppWizardContext";
@@ -12,8 +14,9 @@ import { ext } from "../extensionVariables";
 import { getGitApi } from "../getExtensionApi";
 import { API, CommitOptions, Ref, Repository } from "../git";
 import { ReposGetResponseData } from '../gitHubTypings';
-import { hasAdminAccessToRepo, tryGetRemote, tryGetReposGetResponseData } from "./gitHubUtils";
+import { hasAdminAccessToRepo, tryGetReposGetResponseData } from "./gitHubUtils";
 import { localize } from "./localize";
+import { getSingleRootFsPath } from './workspaceUtils';
 
 export type GitWorkspaceState = { repo: Repository | null, dirty: boolean, remoteRepo: ReposGetResponseData | undefined; hasAdminAccess: boolean };
 export type VerifiedGitWorkspaceState = GitWorkspaceState & { repo: Repository };
@@ -76,6 +79,41 @@ export async function verifyGitWorkspaceForCreation(context: IActionContext, git
     return <VerifiedGitWorkspaceState>gitWorkspaceState;
 }
 
+export async function tryGetRemote(localProjectPath?: string): Promise<string | undefined> {
+    let originUrl: string | void | undefined;
+    localProjectPath = localProjectPath || getSingleRootFsPath();
+    // only try to get remote if provided a path or if there's only a single workspace opened
+    if (localProjectPath) {
+        try {
+            const localGit: git.SimpleGit = git(localProjectPath);
+            originUrl = await localGit.remote(['get-url', 'origin']);
+        } catch (err) {
+            // do nothing, remote origin does not exist
+        }
+    }
+
+    return originUrl ? originUrl : undefined;
+}
+
+export function getRepoFullname(gitUrl: string): { owner: string; name: string } {
+    const parsedUrl: gitUrlParse.GitUrl = gitUrlParse(gitUrl);
+    return { owner: parsedUrl.owner, name: parsedUrl.name };
+}
+
+
+export async function remoteShortnameExists(fsPath: string, remoteName: string): Promise<boolean> {
+    const localGit: git.SimpleGit = git(fsPath);
+    let hasOrigin: boolean = false;
+    try {
+        hasOrigin = !!(await localGit.getRemotes(false)).find(r => { return r.name === remoteName; });
+    } catch (error) {
+        // ignore the error and assume there is no origin
+    }
+
+    return hasOrigin;
+}
+
+
 async function promptForCommit(repo: Repository, value?: string): Promise<void> {
     const commitPrompt: string = localize('commitPrompt', 'Enter a commit message.');
     const commitOptions: CommitOptions = { all: true };
@@ -90,6 +128,21 @@ async function promptForCommit(repo: Repository, value?: string): Promise<void> 
             throw new GitError(err);
         }
     }
+}
+
+export async function tryGetLocalBranch(): Promise<string | undefined> {
+    try {
+        const localProjectPath: string | undefined = getSingleRootFsPath();
+        if (localProjectPath) {
+            // only try to get branch if there's only a single workspace opened
+            const localGit: git.SimpleGit = git(localProjectPath);
+
+            return (await localGit.branch()).current;
+        }
+    } catch (error) {
+        // an error here should be ignored, it probably means that they don't have git installed
+    }
+    return;
 }
 
 export async function promptForDefaultBranch(context: IActionContext, repo: Repository): Promise<void> {


### PR DESCRIPTION
Before this PR https://github.com/microsoft/vscode-azurestaticwebapps/pull/335, there was only gitHubUtils which kind of threw git commands in there as well.  Since I added a gitUtils file, I wanted to refactor some of the functions that were more git specific.

Was also able to delete some GitHub quickpick related code that I forgot to remove.