### PR TITLE
Remove more repo create related code

### DIFF
--- a/src/commands/createRepo/RepoCreateStep.ts
+++ b/src/commands/createRepo/RepoCreateStep.ts
@@ -4,15 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Octokit } from '@octokit/rest';
-import { basename } from 'path';
-import { Progress, Uri } from 'vscode';
+import { Progress } from 'vscode';
 import { AzureWizardExecuteStep } from "vscode-azureextensionui";
 import { ext } from '../../extensionVariables';
-import { getGitApi } from '../../getExtensionApi';
-import { API, Branch, Repository } from '../../git';
+import { Branch, Repository } from '../../git';
 import { isUser } from "../../utils/gitHubUtils";
 import { localize } from '../../utils/localize';
-import { nonNullProp, nonNullValue } from '../../utils/nonNull';
+import { nonNullProp } from '../../utils/nonNull';
 import { IStaticWebAppWizardContext } from '../createStaticWebApp/IStaticWebAppWizardContext';
 import { createOctokitClient } from '../github/createOctokitClient';
 
@@ -38,25 +36,9 @@ export class RepoCreateStep extends AzureWizardExecuteStep<IStaticWebAppWizardCo
         ext.outputChannel.appendLog(createdGitHubRepo);
         progress.report({ message: createdGitHubRepo });
 
-        const git: API = await getGitApi();
-        const fsPath: string = nonNullProp(wizardContext, 'fsPath');
-        const uri: Uri = Uri.file(fsPath);
-        let repo: Repository | null = await git.openRepository(uri);
-
-        if (!repo) {
-            // if there is no repo, it needs to be initialized
-            // https://github.com/microsoft/vscode/issues/111210
-            repo = nonNullValue(await git.init(uri));
-            ext.outputChannel.appendLog(localize('initRepo', 'Initialized repository in local workspace "{0}".', basename(fsPath)));
-        }
-
-        if (!repo.state.HEAD?.commit) {
-            // needs to have an initial commit
-            await repo.commit(localize('initCommit', 'Initial commit'), { all: true });
-            ext.outputChannel.appendLog(localize('commitRepo', 'Created initial commit in local repository.'));
-        }
-
+        const repo: Repository = nonNullProp(wizardContext, 'repo');
         const remoteName: string = nonNullProp(wizardContext, 'newRemoteShortname');
+
         await repo.addRemote(remoteName, gitHubRepoRes.clone_url);
         const branch: Branch = await repo.getBranch('HEAD');
 

--- a/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
+++ b/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
@@ -5,19 +5,18 @@
 
 import { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-appservice';
 import { ICreateChildImplContext, IResourceGroupWizardContext } from 'vscode-azureextensionui';
-import { BranchData, ListOrgsForUserData, OrgForAuthenticatedUserData, RepoData } from '../../gitHubTypings';
+import { Repository } from '../../git';
+import { BranchData, ListOrgsForUserData, OrgForAuthenticatedUserData } from '../../gitHubTypings';
 
-// creating a dummy repoData/branchData would be an annoying amount of work, so use this type to recognize when users have selected create new repo
-export type CreateNewResource = { name?: string; html_url?: string };
 export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext, ICreateChildImplContext {
     accessToken: string;
     client: WebSiteManagementClient;
 
     orgData?: OrgForAuthenticatedUserData | ListOrgsForUserData;
-    repoData?: RepoData | CreateNewResource;
-    branchData?: BranchData | CreateNewResource;
-
+    branchData?: Partial<BranchData>;
     repoHtmlUrl?: string;
+
+    repo?: Repository;
     fsPath?: string;
 
     newStaticWebAppName?: string;
@@ -25,6 +24,7 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext,
     newRepoName?: string;
     newRepoIsPrivate?: boolean;
     newRemoteShortname?: string;
+
     originExists?: boolean;
     gitignoreExists?: boolean;
 
@@ -37,6 +37,7 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext,
     appLocation?: string;
     apiLocation?: string;
     outputLocation?: string;
+
     // created when the wizard is done executing
     staticWebApp?: WebSiteManagementModels.StaticSiteARMResource;
 }

--- a/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
@@ -25,7 +25,7 @@ export class StaticWebAppNameStep extends AzureNameStep<IStaticWebAppWizardConte
         }
 
         const login: string = wizardContext.orgData?.login || owner || 'login';
-        const repo: string = wizardContext.newRepoName || wizardContext.repoData?.name || name || 'repo';
+        const repo: string = wizardContext.newRepoName || name || 'repo';
 
         const prompt: string = localize('staticWebAppNamePrompt', 'Enter a name for the new static web app.');
         wizardContext.newStaticWebAppName = (await ext.ui.showInputBox({

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -36,6 +36,8 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
             context.telemetry.properties.cancelStep = undefined;
 
             context.fsPath = folder.uri.fsPath;
+            context.repo = verifiedWorkspace.repo;
+
             if (gitWorkspaceState.remoteRepo) {
                 context.repoHtmlUrl = gitWorkspaceState.remoteRepo.html_url;
                 context.branchData = { name: gitWorkspaceState.remoteRepo.default_branch };


### PR DESCRIPTION
I forgot that there's a lot of repo creation/commit code in the RepoCreate step that I could delete (since we are enforcing it at the beginning now).

RepoData isn't needed anymore either since we'll have the repoHtml.  BranchData is needed since the branch name gets passed up to the SWA platform.