### PR TITLE
Use build for non-production builds

### DIFF
--- a/src/commands/appSettings/AppSettingsClient.ts
+++ b/src/commands/appSettings/AppSettingsClient.ts
@@ -16,12 +16,17 @@ export class AppSettingsClient implements IAppSettingsClient {
     public fullName: string;
     public resourceGroup: string;
     public root: ISubscriptionContext;
+    public prId: string;
+    public isBuild: boolean;
 
     constructor(node: EnvironmentTreeItem) {
         this.ssId = node.id;
         this.fullName = node.parent.name;
         this.resourceGroup = node.parent.resourceGroup;
         this.root = node.root;
+
+        this.prId = node.buildId;
+        this.isBuild = !node.isProduction;
 
         // For IAppSettingsClient, isLinux is used for app settings key validation and Linux app settings restrictions
         // apply to the keys
@@ -30,11 +35,13 @@ export class AppSettingsClient implements IAppSettingsClient {
 
     public async listApplicationSettings(): Promise<WebSiteManagementModels.StaticSitesCreateOrUpdateStaticSiteFunctionAppSettingsResponse> {
         const client: WebSiteManagementClient = await createWebSiteClient(this.root);
-        return await client.staticSites.listStaticSiteFunctionAppSettings(this.resourceGroup, this.fullName);
+        return this.isBuild ? await client.staticSites.listStaticSiteBuildFunctionAppSettings(this.resourceGroup, this.fullName, this.prId) :
+            await client.staticSites.listStaticSiteFunctionAppSettings(this.resourceGroup, this.fullName);
     }
 
     public async updateApplicationSettings(appSettings: WebSiteManagementModels.StaticSitesCreateOrUpdateStaticSiteFunctionAppSettingsResponse): Promise<WebSiteManagementModels.StaticSitesCreateOrUpdateStaticSiteFunctionAppSettingsResponse> {
         const client: WebSiteManagementClient = await createWebSiteClient(this.root);
-        return await client.staticSites.createOrUpdateStaticSiteFunctionAppSettings(this.resourceGroup, this.fullName, appSettings);
+        return this.isBuild ? await client.staticSites.createOrUpdateStaticSiteBuildFunctionAppSettings(this.resourceGroup, this.fullName, this.prId, appSettings) :
+            await client.staticSites.createOrUpdateStaticSiteFunctionAppSettings(this.resourceGroup, this.fullName, appSettings);
     }
 }

--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -53,9 +53,6 @@ export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureRe
     constructor(parent: StaticWebAppTreeItem, env: WebSiteManagementModels.StaticSiteBuildARMResource) {
         super(parent);
         this.data = env;
-        this.actionsTreeItem = new ActionsTreeItem(this);
-        this.appSettingsTreeItem = new AppSettingsTreeItem(this, new AppSettingsClient(this));
-        this.functionsTreeItem = new FunctionsTreeItem(this);
 
         this.name = nonNullProp(this.data, 'name');
         this.id = nonNullProp(this.data, 'id');
@@ -80,6 +77,10 @@ export class EnvironmentTreeItem extends AzureParentTreeItem implements IAzureRe
             }
         }
         this.label = this.isProduction ? productionEnvironmentName : `${this.data.pullRequestTitle}`;
+
+        this.actionsTreeItem = new ActionsTreeItem(this);
+        this.appSettingsTreeItem = new AppSettingsTreeItem(this, new AppSettingsClient(this));
+        this.functionsTreeItem = new FunctionsTreeItem(this);
     }
 
     public static async createEnvironmentTreeItem(context: IActionContext, parent: StaticWebAppTreeItem, env: WebSiteManagementModels.StaticSiteBuildARMResource): Promise<EnvironmentTreeItem> {

--- a/src/tree/FunctionsTreeItem.ts
+++ b/src/tree/FunctionsTreeItem.ts
@@ -36,7 +36,9 @@ export class FunctionsTreeItem extends AzureParentTreeItem {
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
         const client: WebSiteManagementClient = await createWebSiteClient(this.root);
-        const functions: WebSiteManagementModels.StaticSiteFunctionOverviewCollection = await client.staticSites.listStaticSiteBuildFunctions(this.parent.parent.resourceGroup, this.parent.parent.name, this.parent.buildId);
+        const functions: WebSiteManagementModels.StaticSiteFunctionOverviewCollection = this.parent.isProduction ? await client.staticSites.listStaticSiteFunctions(this.parent.parent.resourceGroup, this.parent.parent.name) :
+            await client.staticSites.listStaticSiteBuildFunctions(this.parent.parent.resourceGroup, this.parent.parent.name, this.parent.buildId);
+
         const treeItems: AzExtTreeItem[] = await this.createTreeItemsWithErrorHandling(
             functions,
             'invalidFunction',

--- a/src/tree/StaticWebAppTreeItem.ts
+++ b/src/tree/StaticWebAppTreeItem.ts
@@ -61,7 +61,6 @@ export class StaticWebAppTreeItem extends AzureParentTreeItem implements IAzureR
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         const client: WebSiteManagementClient = await createWebSiteClient(this.root);
-
         const envs: WebSiteManagementModels.StaticSiteBuildCollection = await client.staticSites.getStaticSiteBuilds(this.resourceGroup, this.name);
 
         return await this.createTreeItemsWithErrorHandling(


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/363

I had to move the treeItem creation further below because it relied on envTreeItem properties that weren't defined yet.

Technically `production` is also a build and it worked fine when I used `listStaticSiteBuildFunctions` (rather than `listStaticSiteFunctions`, but I figured I should change it to use the proper API call in case anything changes in the future.