### PR TITLE
Swap swa name with github repo name steps

### DIFF
--- a/src/commands/createRepo/RepoNameStep.ts
+++ b/src/commands/createRepo/RepoNameStep.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Octokit } from '@octokit/rest';
-import { workspace } from 'vscode';
 import { AzureWizardPromptStep, IParsedError, parseError } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
@@ -14,9 +13,8 @@ import { createOctokitClient } from '../github/createOctokitClient';
 
 export class RepoNameStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
-        const value: string | undefined = workspace.workspaceFolders && await this.validateRepoName(wizardContext, workspace.workspaceFolders[0].name) === undefined ?
-            workspace.workspaceFolders[0].name :
-            undefined;
+        const name: string | undefined = wizardContext.newStaticWebAppName;
+        const value: string | undefined = await this.validateRepoName(wizardContext, name) === undefined ? name : undefined;
 
         wizardContext.newRepoName = (await ext.ui.showInputBox({
             prompt: localize('AppServicePlanPrompt', 'Enter the name of the new GitHub repository. Special characters will be replaced with "-" upon creation.'),

--- a/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
@@ -19,13 +19,12 @@ export const staticWebAppNamingRules: IAzureNamingRules = {
 
 export class StaticWebAppNameStep extends AzureNameStep<IStaticWebAppWizardContext> {
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
-        const sub: string = wizardContext.subscriptionDisplayName;
         const folderName: string = path.basename(nonNullProp(wizardContext, 'fsPath'));
 
         const prompt: string = localize('staticWebAppNamePrompt', 'Enter a name for the new static web app.');
         wizardContext.newStaticWebAppName = (await ext.ui.showInputBox({
             prompt,
-            value: await this.getRelatedName(wizardContext, `${sub}-${folderName}`),
+            value: await this.getRelatedName(wizardContext, folderName),
             validateInput: async (value: string | undefined): Promise<string | undefined> => await this.validateStaticWebAppName(wizardContext, value)
         })).trim();
         wizardContext.valuesToMask.push(wizardContext.newStaticWebAppName);

--- a/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import { AzureNameStep, IAzureNamingRules } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
-import { getRepoFullname } from "../../utils/gitUtils";
 import { localize } from "../../utils/localize";
+import { nonNullProp } from '../../utils/nonNull';
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
 export const staticWebAppNamingRules: IAzureNamingRules = {
@@ -18,19 +19,13 @@ export const staticWebAppNamingRules: IAzureNamingRules = {
 
 export class StaticWebAppNameStep extends AzureNameStep<IStaticWebAppWizardContext> {
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
-        let owner: string | undefined;
-        let name: string | undefined;
-        if (wizardContext.repoHtmlUrl) {
-            ({ owner, name } = getRepoFullname(wizardContext.repoHtmlUrl));
-        }
-
-        const login: string = wizardContext.orgData?.login || owner || 'login';
-        const repo: string = wizardContext.newRepoName || name || 'repo';
+        const sub: string = wizardContext.subscriptionDisplayName;
+        const folderName: string = path.basename(nonNullProp(wizardContext, 'fsPath'));
 
         const prompt: string = localize('staticWebAppNamePrompt', 'Enter a name for the new static web app.');
         wizardContext.newStaticWebAppName = (await ext.ui.showInputBox({
             prompt,
-            value: await this.getRelatedName(wizardContext, `${login}-${repo}`),
+            value: await this.getRelatedName(wizardContext, `${sub}-${folderName}`),
             validateInput: async (value: string | undefined): Promise<string | undefined> => await this.validateStaticWebAppName(wizardContext, value)
         })).trim();
         wizardContext.valuesToMask.push(wizardContext.newStaticWebAppName);

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -59,12 +59,6 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const promptSteps: AzureWizardPromptStep<IStaticWebAppWizardContext>[] = [];
         const executeSteps: AzureWizardExecuteStep<IStaticWebAppWizardContext>[] = [];
 
-        // if the local project doesn't have a GitHub remote, we will create it for them
-        if (!wizardContext.originExists) {
-            promptSteps.push(new GitHubOrgListStep(), new RepoNameStep(), new RepoPrivacyStep(), new RemoteShortnameStep());
-            executeSteps.push(new RepoCreateStep(), new GitignoreCreateStep());
-        }
-
         promptSteps.push(new StaticWebAppNameStep());
 
         if (!context.advancedCreation) {
@@ -74,6 +68,13 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         }
 
         promptSteps.push(new SkuListStep());
+
+        // if the local project doesn't have a GitHub remote, we will create it for them
+        if (!wizardContext.originExists) {
+            promptSteps.push(new GitHubOrgListStep(), new RepoNameStep(), new RepoPrivacyStep(), new RemoteShortnameStep());
+            executeSteps.push(new RepoCreateStep(), new GitignoreCreateStep());
+        }
+
         promptSteps.push(new BuildPresetListStep(), new AppLocationStep(), new ApiLocationStep(), new OutputLocationStep());
 
         // hard-coding locations available during preview


### PR DESCRIPTION
I also moved the GitHub repo create steps _after_ resourceList and skuList steps.  It felt like it made more sense to have all the Azure stuff together rather than doing SWA name, GitHub stuff, and then RG and Sku.  

@fiveisprime Let me know if you think this is weird.