### PR TITLE
Poll for branch data on repo create

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
         "no-unused-vars": "off",
         "no-useless-escape": "off",
         "no-inner-declarations": "off",
+        "no-constant-condition": ["error", { "checkLoops": false }],
         "@typescript-eslint/prefer-regexp-exec": "off",
         "@typescript-eslint/no-unused-vars": [
             "error",


### PR DESCRIPTION
I noticed that in telemetry that we were having some users hitting the following error:
> Internal error: Expected value to be neither null nor undefined: branchData

I could see that this was _only_ happening when we didn't discover a GitHub remote so I figured that there's probably a timing issue when we set `wizardContext.branchData`.  GitHub's API claims that it always returns a branch, so I assumed it would throw an error if it didn't, but it seems like it's returning undefined/null.