### PR TITLE
Add telemetry for workspace settings

### DIFF
--- a/src/commands/createStaticWebApp/ApiLocationStep.ts
+++ b/src/commands/createStaticWebApp/ApiLocationStep.ts
@@ -14,13 +14,14 @@ import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 export class ApiLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const defaultValue: string = context.presetApiLocation || defaultApiLocation;
+        const workspaceSetting: string | undefined = getWorkspaceSetting(apiSubpathSetting, context.fsPath);
 
         context.apiLocation = (await ext.ui.showInputBox({
-            value: getWorkspaceSetting(apiSubpathSetting, context.fsPath) || defaultValue,
+            value: workspaceSetting || defaultValue,
             prompt: localize('enterApiLocation', "Enter the location of your Azure Functions code or leave blank to skip this step. For example, 'api' represents a folder called 'api'."),
         })).trim();
 
-        addLocationTelemetry(context, 'apiLocation', defaultValue);
+        addLocationTelemetry(context, 'apiLocation', defaultValue, workspaceSetting);
     }
 
     public shouldPrompt(context: IStaticWebAppWizardContext): boolean {

--- a/src/commands/createStaticWebApp/AppLocationStep.ts
+++ b/src/commands/createStaticWebApp/AppLocationStep.ts
@@ -13,14 +13,15 @@ import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
 export class AppLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
-        const defaultValue: string = context.presetAppLocation || defaultAppLocation
+        const defaultValue: string = context.presetAppLocation || defaultAppLocation;
+        const workspaceSetting: string | undefined = getWorkspaceSetting(appSubpathSetting, context.fsPath);
 
         context.appLocation = (await ext.ui.showInputBox({
-            value: getWorkspaceSetting(appSubpathSetting, context.fsPath) || defaultValue,
+            value: workspaceSetting || defaultValue,
             prompt: localize('enterAppLocation', "Enter the location of your application code. For example, '/' represents the root of your app, while '/app' represents a directory called 'app'.")
         })).trim();
 
-        addLocationTelemetry(context, 'appLocation', defaultValue);
+        addLocationTelemetry(context, 'appLocation', defaultValue, workspaceSetting);
     }
 
     public shouldPrompt(context: IStaticWebAppWizardContext): boolean {

--- a/src/commands/createStaticWebApp/OutputLocationStep.ts
+++ b/src/commands/createStaticWebApp/OutputLocationStep.ts
@@ -14,12 +14,14 @@ import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 export class OutputLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(wizardContext: IStaticWebAppWizardContext): Promise<void> {
         const defaultValue: string = wizardContext.presetOutputLocation || 'build';
+        const workspaceSetting: string | undefined = getWorkspaceSetting(outputSubpathSetting, wizardContext.fsPath);
+
         wizardContext.outputLocation = (await ext.ui.showInputBox({
-            value: getWorkspaceSetting(outputSubpathSetting, wizardContext.fsPath) || getWorkspaceSetting(appArtifactSubpathSetting, wizardContext.fsPath) || defaultValue,
+            value: workspaceSetting || getWorkspaceSetting(appArtifactSubpathSetting, wizardContext.fsPath) || defaultValue,
             prompt: localize('publishLocation', "Enter the location of your build output relative to your app's location or leave blank if it has no build. For example, setting a value of 'build' when your app location is set to 'app' will cause the content at 'app/build' to be served.")
         })).trim();
 
-        addLocationTelemetry(wizardContext, 'outputLocation', defaultValue);
+        addLocationTelemetry(wizardContext, 'outputLocation', defaultValue, workspaceSetting);
     }
 
     public shouldPrompt(wizardContext: IStaticWebAppWizardContext): boolean {

--- a/src/commands/createStaticWebApp/addLocationTelemetry.ts
+++ b/src/commands/createStaticWebApp/addLocationTelemetry.ts
@@ -7,16 +7,19 @@ import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
 export function addLocationTelemetry(wizardContext: IStaticWebAppWizardContext, key: 'appLocation' | 'apiLocation' | 'outputLocation', defaultValue: string, valueFromSetting?: string): void {
     const value: string | undefined = wizardContext[key];
+    wizardContext.telemetry.properties[`${key}HasSetting`] = (!!valueFromSetting).toString();
+    wizardContext.telemetry.properties[`${key}MatchesSetting`] = (defaultValue === valueFromSetting).toString();
+
     let telemValue: string;
     if (value === undefined) {
         // no telemetry to add yet
         return;
     } else if (value.length === 0) {
         telemValue = 'empty';
-    } else if (value === valueFromSetting) {
-        telemValue = 'setting';
     } else if (value === defaultValue) {
         telemValue = 'default';
+    } else if (value === valueFromSetting) {
+        telemValue = 'setting';
     } else {
         telemValue = 'nonDefault';
     }

--- a/src/commands/createStaticWebApp/addLocationTelemetry.ts
+++ b/src/commands/createStaticWebApp/addLocationTelemetry.ts
@@ -5,7 +5,7 @@
 
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
-export function addLocationTelemetry(wizardContext: IStaticWebAppWizardContext, key: 'appLocation' | 'apiLocation' | 'outputLocation', defaultValue: string): void {
+export function addLocationTelemetry(wizardContext: IStaticWebAppWizardContext, key: 'appLocation' | 'apiLocation' | 'outputLocation', defaultValue: string, valueFromSetting?: string): void {
     const value: string | undefined = wizardContext[key];
     let telemValue: string;
     if (value === undefined) {
@@ -13,6 +13,8 @@ export function addLocationTelemetry(wizardContext: IStaticWebAppWizardContext, 
         return;
     } else if (value.length === 0) {
         telemValue = 'empty';
+    } else if (value === valueFromSetting) {
+        telemValue = 'setting';
     } else if (value === defaultValue) {
         telemValue = 'default';
     } else {

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -10,9 +10,8 @@ import { ext } from '../../extensionVariables';
 import { EnvironmentTreeItem } from '../../tree/EnvironmentTreeItem';
 import { StaticWebAppTreeItem } from '../../tree/StaticWebAppTreeItem';
 import { SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
-import { getGitWorkspaceState, gitPull, GitWorkspaceState, VerifiedGitWorkspaceState, verifyGitWorkspaceForCreation, warnIfNotOnDefaultBranch } from '../../utils/gitUtils';
+import { getGitWorkspaceState, GitWorkspaceState, VerifiedGitWorkspaceState, verifyGitWorkspaceForCreation, warnIfNotOnDefaultBranch } from '../../utils/gitUtils';
 import { localize } from '../../utils/localize';
-import { nonNullProp } from '../../utils/nonNull';
 import { getWorkspaceFolder } from '../../utils/workspaceUtils';
 import { showSwaCreated } from '../showSwaCreated';
 import { GitHubOrgListStep } from './GitHubOrgListStep';
@@ -56,8 +55,6 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
     });
 
     const swaNode: StaticWebAppTreeItem = await node.createChild(context);
-
-    await gitPull(nonNullProp(context, 'repo'));
     void showSwaCreated(swaNode);
 
     const environmentNode: EnvironmentTreeItem | undefined = <EnvironmentTreeItem | undefined>(await swaNode.loadAllChildren(context)).find(ti => {
@@ -66,7 +63,6 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
     environmentNode && await ext.treeView.reveal(environmentNode, { expand: true });
 
     void postCreateStaticWebApp(swaNode);
-
     return swaNode;
 }
 

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -22,6 +22,7 @@ import { StaticWebAppNameStep } from '../commands/createStaticWebApp/StaticWebAp
 import { apiSubpathSetting, appSubpathSetting, outputSubpathSetting } from '../constants';
 import { createWebSiteClient } from '../utils/azureClients';
 import { getGitHubAccessToken } from '../utils/gitHubUtils';
+import { gitPull } from '../utils/gitUtils';
 import { localize } from '../utils/localize';
 import { nonNullProp } from '../utils/nonNull';
 import { updateWorkspaceSetting } from '../utils/settingsUtils';
@@ -123,6 +124,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         await wizard.execute();
         context.showCreatingTreeItem(newStaticWebAppName);
 
+        await gitPull(nonNullProp(wizardContext, 'repo'));
         if (wizardContext.fsPath && hasRemote) {
             await updateWorkspaceSetting(appSubpathSetting, wizardContext.appLocation, wizardContext.fsPath);
             await updateWorkspaceSetting(apiSubpathSetting, wizardContext.apiLocation, wizardContext.fsPath);


### PR DESCRIPTION
I wanted to add some telemetry on how often workspace settings get used.  I'm seeing a lot of 'non-default' values, but it's very possible that users are just typing their own values.

I wanted to remove the settings from being added since with the current workspace requirements, it'll add the settings silently every time.  I'm thinking maybe we should have a notification or a setting to disable that behavior.  The main downside to it is that it makes the repo dirty and can potentially screw up the `git pull` we do for the workflow file since they're both existing in the .vscode folder.

I'm moving git pull to before the settings getting added for now to help mitigate that problem, but it is still weird to have your repo be "dirty" immediately after creating your SWA.