### PR TITLE
Set relatedNameTask for all creation

### DIFF
--- a/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
@@ -27,11 +27,9 @@ export class StaticWebAppNameStep extends AzureNameStep<IStaticWebAppWizardConte
             value: await this.getRelatedName(wizardContext, folderName),
             validateInput: async (value: string | undefined): Promise<string | undefined> => await this.validateStaticWebAppName(wizardContext, value)
         })).trim();
-        wizardContext.valuesToMask.push(wizardContext.newStaticWebAppName);
 
-        if (wizardContext.advancedCreation) {
-            wizardContext.relatedNameTask = this.getRelatedName(wizardContext, wizardContext.newStaticWebAppName);
-        }
+        wizardContext.valuesToMask.push(wizardContext.newStaticWebAppName);
+        wizardContext.relatedNameTask = this.getRelatedName(wizardContext, wizardContext.newStaticWebAppName);
     }
 
     public shouldPrompt(wizardContext: IStaticWebAppWizardContext): boolean {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/432

Forgot to set the `relatedNameTask` for everything now that I'm properly using it for the resourceGroup name in basic create.