### PR TITLE
Add "Sign in with GitHub" item in Accounts activity bar item

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,9 @@ export const showActionsMsg: MessageItem = { title: localize('openActions', 'Ope
 
 export const onlyGitHubSupported: string = localize('onlyGitHubSupported', 'Only Static Web Apps linked to GitHub are supported at this time.');
 
+export const githubAuthProviderId: string = 'github';
+export const githubScopes: string[] = ['repo', 'workflow', 'admin:public_key'];
+
 // Source: https://github.com/github/gitignore/blob/master/Node.gitignore
 export const defaultGitignoreContents: string = `# Logs
 logs

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { AzExtTreeDataProvider, callWithTelemetryAndErrorHandling, createApiProv
 import { AzureExtensionApi, AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { revealTreeItem } from './commands/api/revealTreeItem';
 import { registerCommands } from './commands/registerCommands';
+import { githubAuthProviderId, githubScopes } from './constants';
 import { ext } from './extensionVariables';
 import { AzureAccountTreeItem } from './tree/AzureAccountTreeItemWithProjects';
 
@@ -26,6 +27,12 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     await callWithTelemetryAndErrorHandling('staticWebApps.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
+
+        /**
+         * By passing `createIfNone: false`, a numbered badge will show up on the accounts activity bar icon.
+         * An entry for the extension will be added under the menu to sign in.
+         */
+        await vscode.authentication.getSession(githubAuthProviderId, githubScopes, { createIfNone: false });
 
         const accountTreeItem: AzureAccountTreeItem = new AzureAccountTreeItem();
         context.subscriptions.push(accountTreeItem);

--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -7,6 +7,7 @@ import { Octokit } from '@octokit/rest';
 import { authentication, ProgressLocation, window } from 'vscode';
 import { IActionContext, IAzureQuickPickItem, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { createOctokitClient } from '../commands/github/createOctokitClient';
+import { githubAuthProviderId, githubScopes } from '../constants';
 import { ext } from '../extensionVariables';
 import { ListOrgsForUserData, OrgForAuthenticatedUserData, ReposCreateForkResponse, ReposGetResponseData } from '../gitHubTypings';
 import { getRepoFullname, tryGetRemote } from './gitUtils';
@@ -37,9 +38,8 @@ export function createQuickPickFromJsons<T>(data: T[], label: string): IAzureQui
 }
 
 export async function getGitHubAccessToken(): Promise<string> {
-    const scopes: string[] = ['repo', 'workflow', 'admin:public_key'];
     try {
-        return (await authentication.getSession('github', scopes, { createIfNone: true })).accessToken;
+        return (await authentication.getSession(githubAuthProviderId, githubScopes, { createIfNone: true })).accessToken;
     } catch (error) {
         if (parseError(error).message === 'User did not consent to login.') {
             throw new UserCancelledError('getGitHubToken');


### PR DESCRIPTION
Fixes #450 

Other extensions like GitLens and the GitHub Pull Request extension create menu items in the Accounts activity bar item to notify users to sign in with GitHub.

I verified:
* If a user signs in using this menu, they won't have to sign in again later for our extension.
* The menu item does not show up if the user has signed in with GitHub for SWA.

Example extension showing this feature: https://github.com/microsoft/vscode-extension-samples/tree/main/github-authentication-sample

Relevant lines of code from example extension: https://github.com/microsoft/vscode-extension-samples/blob/d885d442faa3082ceb8f6f182462d17ce7347d6e/github-authentication-sample/src/credentials.ts#L18-L23

<img width="460" alt="Screen Shot 2021-07-20 at 2 00 55 PM" src="https://user-images.githubusercontent.com/12476526/126397394-7786092b-2795-4240-b73b-b845584a82db.png">