### PR TITLE
Add "Create from template" option when there are no workspace folders

### DIFF
--- a/src/commands/createRepo/CreateRepoFromTemplateStep.ts
+++ b/src/commands/createRepo/CreateRepoFromTemplateStep.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Progress } from 'vscode';
+import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
+import { createRepoFromTemplate } from '../../utils/gitHubUtils';
+import { localize } from '../../utils/localize';
+import { nonNullProp } from '../../utils/nonNull';
+import { IStaticWebAppWizardContext } from '../createStaticWebApp/IStaticWebAppWizardContext';
+
+export class CreateRepoFromTemplateStep extends AzureWizardExecuteStep<IStaticWebAppWizardContext> {
+    public priority: number = 100;
+    public async execute(wizardContext: IStaticWebAppWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined; }>): Promise<void> {
+
+
+        const creatingRepository: string = localize('creatingSwa', 'Creating repository from template');
+        progress.report({ message: creatingRepository });
+
+        wizardContext.repoCreatedFromTemplate = await createRepoFromTemplate(wizardContext, nonNullProp(wizardContext, 'templateRepo'), nonNullProp(wizardContext, 'newRepoName'));
+    }
+    public shouldExecute(wizardContext: IStaticWebAppWizardContext): boolean {
+        // only execute if a repo hasn't already been created
+        return !wizardContext.repoCreatedFromTemplate;
+    }
+}

--- a/src/commands/createRepo/CreateRepoFromTemplateStep.ts
+++ b/src/commands/createRepo/CreateRepoFromTemplateStep.ts
@@ -13,12 +13,10 @@ import { IStaticWebAppWizardContext } from '../createStaticWebApp/IStaticWebAppW
 export class CreateRepoFromTemplateStep extends AzureWizardExecuteStep<IStaticWebAppWizardContext> {
     public priority: number = 100;
     public async execute(wizardContext: IStaticWebAppWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined; }>): Promise<void> {
-
-
-        const creatingRepository: string = localize('creatingSwa', 'Creating repository from template');
-        progress.report({ message: creatingRepository });
-
-        wizardContext.repoCreatedFromTemplate = await createRepoFromTemplate(wizardContext, nonNullProp(wizardContext, 'templateRepo'), nonNullProp(wizardContext, 'newRepoName'));
+        const newRepoName = nonNullProp(wizardContext, 'newRepoName');
+        const creatingGitHubRepo: string = localize('creatingPublicGitHubRepo', 'Creating new public GitHub repository "{0}"...', newRepoName);
+        progress.report({ message: creatingGitHubRepo });
+        wizardContext.repoCreatedFromTemplate = await createRepoFromTemplate(wizardContext, nonNullProp(wizardContext, 'templateRepo'), newRepoName);
     }
     public shouldExecute(wizardContext: IStaticWebAppWizardContext): boolean {
         // only execute if a repo hasn't already been created

--- a/src/commands/createRepo/PickTemplateStep.ts
+++ b/src/commands/createRepo/PickTemplateStep.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { RepoData } from '../../gitHubTypings';
+import { localize } from '../../utils/localize';
+import { getTemplateReposFromGitHub } from '../../utils/templateUtils';
+import { IStaticWebAppWizardContext } from '../createStaticWebApp/IStaticWebAppWizardContext';
+
+export class PickTemplateStep extends AzureWizardPromptStep<Partial<IStaticWebAppWizardContext> & IActionContext> {
+    public async prompt(context: Partial<IStaticWebAppWizardContext> & IActionContext): Promise<void> {
+        const templateRepos: RepoData[] = await getTemplateReposFromGitHub(context);
+
+        const placeHolder: string = localize('chooseTemplatePrompt', 'Choose a static web app template for the new repository.');
+        const picks: IAzureQuickPickItem<RepoData>[] = templateRepos.map((repo) => { return { label: repo.name, data: repo }; });
+        const pick: IAzureQuickPickItem<RepoData> = await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true });
+
+        context.templateRepo = pick.data;
+    }
+
+    public shouldPrompt(context: Partial<IStaticWebAppWizardContext> & IActionContext): boolean {
+        return !context.templateRepo;
+    }
+}

--- a/src/commands/createRepo/RepoNameStep.ts
+++ b/src/commands/createRepo/RepoNameStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Octokit } from '@octokit/rest';
-import { AzureWizardPromptStep, IParsedError, parseError } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep, IActionContext, IParsedError, parseError } from 'vscode-azureextensionui';
 import { localize } from '../../utils/localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { IStaticWebAppWizardContext } from '../createStaticWebApp/IStaticWebAppWizardContext';
@@ -13,11 +13,11 @@ import { createOctokitClient } from '../github/createOctokitClient';
 export class RepoNameStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const name: string | undefined = context.newStaticWebAppName;
-        const value: string | undefined = await this.validateRepoName(context, name) === undefined ? name : undefined;
+        const value: string | undefined = await RepoNameStep.validateRepoName(context, name) === undefined ? name : undefined;
 
         context.newRepoName = (await context.ui.showInputBox({
             prompt: localize('newRepoPrompt', 'Enter the name of the new GitHub repository. Azure Static Web Apps automatically builds and deploys using GitHub Actions.'),
-            validateInput: async (value: string): Promise<string | undefined> => await this.validateRepoName(context, value),
+            validateInput: async (value: string): Promise<string | undefined> => await RepoNameStep.validateRepoName(context, value),
             value
         })).trim();
         context.valuesToMask.push(context.newRepoName);
@@ -27,7 +27,21 @@ export class RepoNameStep extends AzureWizardPromptStep<IStaticWebAppWizardConte
         return !context.newRepoName;
     }
 
-    protected async isRepoAvailable(context: IStaticWebAppWizardContext, repo: string): Promise<boolean> {
+    public static async validateRepoName(context: Partial<IStaticWebAppWizardContext> & IActionContext, name: string | undefined): Promise<string | undefined> {
+        name = name ? name.trim() : '';
+
+        if (name === '.' || name === '..') {
+            return localize('reserved', 'The repository "{0}" is reserved.', name);
+        } else if (name.length < 1) {
+            return localize('invalidLength', 'The name must be between at least 1 character.');
+        } else if (!await this.isRepoAvailable(context, name)) {
+            return localize('nameUnavailable', 'The repository "{0}" already exists on this account.', name);
+        } else {
+            return undefined;
+        }
+    }
+
+    private static async isRepoAvailable(context: Partial<IStaticWebAppWizardContext> & IActionContext, repo: string): Promise<boolean> {
         const client: Octokit = await createOctokitClient(context);
         try {
             await client.repos.get({ owner: nonNullProp(context, 'orgData').login, repo });
@@ -42,19 +56,5 @@ export class RepoNameStep extends AzureWizardPromptStep<IStaticWebAppWizardConte
         }
 
         return false;
-    }
-
-    private async validateRepoName(context: IStaticWebAppWizardContext, name: string | undefined): Promise<string | undefined> {
-        name = name ? name.trim() : '';
-
-        if (name === '.' || name === '..') {
-            return localize('reserved', 'The repository "{0}" is reserved.', name);
-        } else if (name.length < 1) {
-            return localize('invalidLength', 'The name must be between at least 1 character.');
-        } else if (!await this.isRepoAvailable(context, name)) {
-            return localize('nameUnavailable', 'The repository "{0}" already exists on this account.', name);
-        } else {
-            return undefined;
-        }
     }
 }

--- a/src/commands/createRepo/TemplateRepoNameStep.ts
+++ b/src/commands/createRepo/TemplateRepoNameStep.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, IActionContext } from 'vscode-azureextensionui';
+import { localize } from '../../utils/localize';
+import { nonNullValueAndProp } from '../../utils/nonNull';
+import { GitHubOrgListStep } from '../createStaticWebApp/GitHubOrgListStep';
+import { IStaticWebAppWizardContext } from '../createStaticWebApp/IStaticWebAppWizardContext';
+import { RepoNameStep } from './RepoNameStep';
+
+export class TemplateRepoNameStep extends AzureWizardPromptStep<Partial<IStaticWebAppWizardContext> & IActionContext> {
+    public async prompt(context: Partial<IStaticWebAppWizardContext> & IActionContext): Promise<void> {
+        const templateName = nonNullValueAndProp(context.templateRepo, 'name');
+
+        const validateNameContext: Partial<IStaticWebAppWizardContext> & IActionContext = {
+            ...context,
+            orgData: await GitHubOrgListStep.getAuthenticatedUser(context)
+        }
+
+        const validateRepoName = async (value: string): Promise<string | undefined> => await RepoNameStep.validateRepoName(validateNameContext, value);
+        const isTemplateNameAValidRepoName = !(await validateRepoName(templateName));
+        context.newRepoName = await context.ui.showInputBox({
+            validateInput: validateRepoName,
+            prompt: localize('newRepoFromTemplatePrompt', 'Enter the name of the new GitHub repository to create from the "{0}" template.', templateName),
+            value: isTemplateNameAValidRepoName ? templateName : ''
+        });
+
+        context.valuesToMask.push(context.newRepoName);
+    }
+
+    public shouldPrompt(context: Partial<IStaticWebAppWizardContext> & IActionContext): boolean {
+        // must have picked a template and not have a name
+        return !!context.templateRepo && !context.newRepoName;
+    }
+}

--- a/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
+++ b/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
@@ -7,7 +7,7 @@ import { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-app
 import { ICreateChildImplContext, IResourceGroupWizardContext } from 'vscode-azureextensionui';
 import { IBuildPreset } from '../../buildPresets/IBuildPreset';
 import { Repository } from '../../git';
-import { BranchData, ListOrgsForUserData, OrgForAuthenticatedUserData } from '../../gitHubTypings';
+import { BranchData, ListOrgsForUserData, OrgForAuthenticatedUserData, RepoData, ReposCreateUsingTemplateResponse } from '../../gitHubTypings';
 
 export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext, ICreateChildImplContext {
     accessToken: string;
@@ -40,4 +40,7 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext,
 
     // created when the wizard is done executing
     staticWebApp?: WebSiteManagementModels.StaticSiteARMResource;
+
+    templateRepo?: RepoData;
+    repoCreatedFromTemplate?: ReposCreateUsingTemplateResponse;
 }

--- a/src/commands/github/createOctokitClient.ts
+++ b/src/commands/github/createOctokitClient.ts
@@ -14,6 +14,12 @@ export async function createOctokitClient(context: IActionContext & Partial<ISta
     return new Octokit(
         {
             userAgent: appendExtensionUserAgent(),
-            auth: token
+            auth: token,
+            /**
+             * 'baptiste' preview needed to work with template repos
+             * see https://docs.github.com/en/rest/overview/api-previews#create-and-use-repository-templates
+             * and https://developer.github.com/changes/2019-07-16-repository-templates-api/
+             */
+            previews: ['baptiste']
         });
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,8 @@ export const onlyGitHubSupported: string = localize('onlyGitHubSupported', 'Only
 export const githubAuthProviderId: string = 'github';
 export const githubScopes: string[] = ['repo', 'workflow', 'admin:public_key'];
 
+export const templateReposUsername: string = 'staticwebdev';
+
 // Source: https://github.com/github/gitignore/blob/master/Node.gitignore
 export const defaultGitignoreContents: string = `# Logs
 logs

--- a/src/gitHubTypings.ts
+++ b/src/gitHubTypings.ts
@@ -24,6 +24,7 @@ export type BranchData = Endpoints["GET /repos/{owner}/{repo}/branches"]["respon
 export type RepoResponse = Endpoints["GET /orgs/{org}/repos"]["response"] | Endpoints["GET /users/{username}/repos"]["response"];
 
 export type ReposCreateForkResponse = RestEndpointMethodTypes["repos"]["createFork"]["response"];
+export type ReposCreateUsingTemplateResponse = RestEndpointMethodTypes["repos"]["createUsingTemplate"]["response"];
 
 // Doc for these parameter values: https://developer.github.com/v3/checks/runs/#parameters
 export enum Conclusion {

--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -7,9 +7,9 @@ import { Octokit } from '@octokit/rest';
 import { authentication, ProgressLocation, window } from 'vscode';
 import { IActionContext, IAzureQuickPickItem, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { createOctokitClient } from '../commands/github/createOctokitClient';
-import { githubAuthProviderId, githubScopes, templateReposUsername } from '../constants';
+import { githubAuthProviderId, githubScopes } from '../constants';
 import { ext } from '../extensionVariables';
-import { ListOrgsForUserData, OrgForAuthenticatedUserData, RepoData, RepoResponse, ReposCreateForkResponse, ReposCreateUsingTemplateResponse, ReposGetResponseData } from '../gitHubTypings';
+import { ListOrgsForUserData, OrgForAuthenticatedUserData, RepoData, ReposCreateForkResponse, ReposCreateUsingTemplateResponse, ReposGetResponseData } from '../gitHubTypings';
 import { getRepoFullname, tryGetRemote } from './gitUtils';
 import { localize } from './localize';
 import { nonNullProp } from './nonNull';
@@ -124,14 +124,4 @@ export async function createRepoFromTemplate(context: IActionContext, templateRe
         const generateUrl: string = `${templateRepo.html_url}/generate`;
         throw new Error(localize('createFromTemplateFail', 'Could not create repository from template. [Click here to create it manually]({0}).', generateUrl));
     }
-}
-
-export async function getTemplateRepos(context: IActionContext): Promise<RepoData[]> {
-    const client: Octokit = await createOctokitClient(context);
-
-    const allRepositories: RepoResponse = await client.repos.listForUser({
-        username: templateReposUsername
-    });
-
-    return allRepositories.data.filter((repo) => repo.is_template);
 }

--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -7,9 +7,9 @@ import { Octokit } from '@octokit/rest';
 import { authentication, ProgressLocation, window } from 'vscode';
 import { IActionContext, IAzureQuickPickItem, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { createOctokitClient } from '../commands/github/createOctokitClient';
-import { githubAuthProviderId, githubScopes } from '../constants';
+import { githubAuthProviderId, githubScopes, templateReposUsername } from '../constants';
 import { ext } from '../extensionVariables';
-import { ListOrgsForUserData, OrgForAuthenticatedUserData, ReposCreateForkResponse, ReposGetResponseData } from '../gitHubTypings';
+import { ListOrgsForUserData, OrgForAuthenticatedUserData, RepoData, RepoResponse, ReposCreateForkResponse, ReposCreateUsingTemplateResponse, ReposGetResponseData } from '../gitHubTypings';
 import { getRepoFullname, tryGetRemote } from './gitUtils';
 import { localize } from './localize';
 import { nonNullProp } from './nonNull';
@@ -104,4 +104,34 @@ export async function createFork(context: IActionContext, remoteRepo: ReposGetRe
     } else {
         throw new Error(localize('forkFail', 'Could not automatically fork repository. Please fork [{0}]({1}) manually.', remoteRepo.name, remoteRepo.html_url));
     }
+}
+
+export async function createRepoFromTemplate(context: IActionContext, templateRepo: RepoData, newRepoName?: string, isPrivate?: boolean, description?: string): Promise<ReposCreateUsingTemplateResponse> {
+    if (!templateRepo.is_template) {
+        throw new Error(localize('repoNotATemplate', 'Could not create repository. "{0}" is not a template.', templateRepo.full_name));
+    }
+
+    const client: Octokit = await createOctokitClient(context);
+    try {
+        return client.rest.repos.createUsingTemplate({
+            template_owner: nonNullProp(templateRepo, 'owner').login,
+            template_repo: templateRepo.name,
+            name: newRepoName ?? templateRepo.name,
+            private: isPrivate ?? false,
+            description: description ?? undefined
+        });
+    } catch (e) {
+        const generateUrl: string = `${templateRepo.html_url}/generate`;
+        throw new Error(localize('createFromTemplateFail', 'Could not create repository from template. [Click here to create it manually]({0}).', generateUrl));
+    }
+}
+
+export async function getTemplateRepos(context: IActionContext): Promise<RepoData[]> {
+    const client: Octokit = await createOctokitClient(context);
+
+    const allRepositories: RepoResponse = await client.repos.listForUser({
+        username: templateReposUsername
+    });
+
+    return allRepositories.data.filter((repo) => repo.is_template);
 }

--- a/src/utils/templateUtils.ts
+++ b/src/utils/templateUtils.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { RepoNameStep } from '../commands/createRepo/RepoNameStep';
+import { GitHubOrgListStep } from '../commands/createStaticWebApp/GitHubOrgListStep';
+import { IStaticWebAppWizardContext } from '../commands/createStaticWebApp/IStaticWebAppWizardContext';
+import { RepoData } from '../gitHubTypings';
+import { getTemplateRepos } from './gitHubUtils';
+import { localize } from './localize';
+
+export async function pickTemplate(context: IActionContext): Promise<RepoData> {
+    const templateRepos: RepoData[] = await getTemplateRepos(context);
+
+    const placeHolder: string = localize('chooseTemplatePrompt', 'Choose a static web app template for the new repository.');
+    const picks: IAzureQuickPickItem<RepoData>[] = templateRepos.map((repo) => { return { label: repo.name, data: repo }; });
+    const pick: IAzureQuickPickItem<RepoData> = await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true });
+
+    return pick.data;
+}
+
+export async function promptForTemplateRepoName(context: IActionContext, template: RepoData): Promise<string> {
+    const templateName = template.name;
+
+    const validateNameContext: Partial<IStaticWebAppWizardContext> & IActionContext = {
+        ...context,
+        orgData: await GitHubOrgListStep.getAuthenticatedUser(context)
+    }
+
+    const validateRepoName = async (value: string): Promise<string | undefined> => await RepoNameStep.validateRepoName(validateNameContext, value);
+    const isTemplateNameAValidRepoName = !(await validateRepoName(templateName));
+    const newRepoName = await context.ui.showInputBox({
+        validateInput: validateRepoName,
+        prompt: localize('newRepoFromTemplatePrompt', 'Enter the name of the new GitHub repository to create from the "{0}" template.', templateName),
+        value: isTemplateNameAValidRepoName ? templateName : ''
+    });
+
+    return newRepoName;
+}

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -6,14 +6,11 @@
 import * as path from 'path';
 import { commands, MessageItem, OpenDialogOptions, Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { IActionContext, IAzureQuickPickItem, UserCancelledError } from "vscode-azureextensionui";
-import { RepoNameStep } from '../commands/createRepo/RepoNameStep';
-import { GitHubOrgListStep } from '../commands/createStaticWebApp/GitHubOrgListStep';
-import { IStaticWebAppWizardContext } from '../commands/createStaticWebApp/IStaticWebAppWizardContext';
 import { cloneRepo } from '../commands/github/cloneRepo';
 import { NoWorkspaceError } from '../errors';
-import { RepoData } from '../gitHubTypings';
-import { createRepoFromTemplate, getTemplateRepos } from './gitHubUtils';
+import { createRepoFromTemplate } from './gitHubUtils';
 import { localize } from "./localize";
+import { pickTemplate, promptForTemplateRepoName } from './templateUtils';
 
 export function getSingleRootFsPath(): string | undefined {
     // if this is no workspace or a multi-root workspace, return undefined
@@ -104,33 +101,4 @@ export async function getWorkspaceFolder(context: IActionContext): Promise<Works
     }
 
     return folder;
-}
-
-async function pickTemplate(context: IActionContext): Promise<RepoData> {
-    const templateRepos: RepoData[] = await getTemplateRepos(context);
-
-    const placeHolder: string = localize('chooseTemplatePrompt', 'Choose a static web app template for the new repository.');
-    const picks: IAzureQuickPickItem<RepoData>[] = templateRepos.map((repo) => { return { label: repo.name, data: repo }; });
-    const pick: IAzureQuickPickItem<RepoData> = await context.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true });
-
-    return pick.data;
-}
-
-async function promptForTemplateRepoName(context: IActionContext, template: RepoData): Promise<string> {
-    const templateName = template.name;
-
-    const validateNameContext: Partial<IStaticWebAppWizardContext> & IActionContext = {
-        ...context,
-        orgData: await GitHubOrgListStep.getAuthenticatedUser(context)
-    }
-
-    const validateRepoName = async (value: string): Promise<string | undefined> => await RepoNameStep.validateRepoName(validateNameContext, value);
-    const isTemplateNameAValidRepoName = !(await validateRepoName(templateName));
-    const newRepoName = await context.ui.showInputBox({
-        validateInput: validateRepoName,
-        prompt: localize('newRepoFromTemplatePrompt', 'Enter the name of the new GitHub repository to create from the "{0}" template.', templateName),
-        value: isTemplateNameAValidRepoName ? templateName : ''
-    });
-
-    return newRepoName;
 }

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -81,7 +81,7 @@ export async function getWorkspaceFolder(context: IActionContext): Promise<Works
             const newRepoName = await promptForTemplateRepoName(context, pickedTemplate);
             const repoCreatedFromTemplate = await createRepoFromTemplate(context, pickedTemplate, newRepoName);
             await cloneRepo(context, repoCreatedFromTemplate.data.html_url);
-            context.telemetry.properties.noWorkspaceResult = 'template';
+            context.telemetry.properties.noWorkspaceResult = 'createFromTemplate';
         }
 
         context.errorHandling.suppressDisplay = true;


### PR DESCRIPTION
When a user has no workspace, a new option for "Create from template" is available that allows the users to select a repo from a list we pull from the templates available on https://github.com/staticwebdev. After entering a repo name we create the repo on GitHub for them and clone it.

Note: I omitted the GitHub org prompt because we currently don't have a way to check if the user has permissions to create a repository on the org. I looked into how to do this and it seemed like more work than I wanted to include in this PR.

Screenshots: 

<img width="571" alt="Screen Shot 2021-07-27 at 4 57 32 PM" src="https://user-images.githubusercontent.com/12476526/127242406-d1dc3829-7a45-494e-8708-da15e3657855.png">

Pick template prompt:
<img width="619" alt="Screen Shot 2021-07-27 at 4 58 19 PM" src="https://user-images.githubusercontent.com/12476526/127242436-29af42ab-4cef-4139-b950-662801a018f3.png">

Get repo name prompt:
![image](https://user-images.githubusercontent.com/12476526/127242496-f79a15e0-ae08-4b1a-b3e5-a2092a98797b.png)
