### PR TITLE
Handle invalid workflow YAML files gracefully

### DIFF
--- a/src/commands/openYAMLConfigFile.ts
+++ b/src/commands/openYAMLConfigFile.ts
@@ -48,11 +48,19 @@ export async function openYAMLConfigFile(context: IActionContext, node?: StaticW
     }
 
     const configDocument: TextDocument = await workspace.openTextDocument(yamlFilePath);
-    const selection: Range | undefined = buildConfigToSelect ? await tryGetSelection(context, configDocument, buildConfigToSelect) : undefined;
+    const selection: Range | undefined = await tryGetSelection(context, configDocument, buildConfigToSelect, node instanceof GitHubConfigGroupTreeItem ? node : undefined);
     await window.showTextDocument(configDocument, { selection });
 }
 
-export async function tryGetSelection(context: IActionContext, configDocument: TextDocument, buildConfigToSelect: BuildConfig): Promise<Range | undefined> {
+export async function tryGetSelection(context: IActionContext, configDocument: TextDocument, buildConfigToSelect?: BuildConfig, node?: GitHubConfigGroupTreeItem): Promise<Range | undefined> {
+    if (node?.errorRange) {
+        return node.errorRange;
+    }
+
+    if (!buildConfigToSelect) {
+        return undefined;
+    }
+
     const configDocumentText: string = configDocument.getText();
     const buildConfigRegex: RegExp = new RegExp(`${buildConfigToSelect}:`, 'g');
     const buildConfigMatches: RegExpMatchArray | null = configDocumentText.match(buildConfigRegex);

--- a/src/tree/GitHubConfigGroupTreeItem.ts
+++ b/src/tree/GitHubConfigGroupTreeItem.ts
@@ -5,8 +5,10 @@
 
 import { pathExists, readdir } from "fs-extra";
 import { basename, join } from "path";
-import { ThemeIcon } from "vscode";
-import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, TreeItemIconPath } from "vscode-azureextensionui";
+import { Range, ThemeIcon } from "vscode";
+import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, parseError, TreeItemIconPath } from "vscode-azureextensionui";
+// eslint-disable-next-line import/no-internal-modules
+import { YAMLSyntaxError } from "yaml/util";
 import { localize } from "../utils/localize";
 import { parseYamlFile } from "../utils/yamlUtils";
 import { EnvironmentTreeItem } from "./EnvironmentTreeItem";
@@ -21,19 +23,44 @@ export type BuildConfigs = {
     'app_artifact_location'?: string
 }
 
+function getRangeFromError(error: YAMLSyntaxError): Range {
+    if (error.linePos) {
+        const { start, end } = error.linePos;
+        return new Range(start.line - 1, start.col - 1, end.line - 1, end.col - 1);
+    }
+    return new Range(0, 0, 0, 0);
+}
+
+function getYamlErrorMessage(error: unknown): string {
+    if (error instanceof YAMLSyntaxError) {
+        const range = getRangeFromError(error);
+        return `Error: Invalid YAML between lines ${range.start.line} and ${range.end.line}`;
+    } else {
+        return parseError(error).message;
+    }
+}
+
 export class GitHubConfigGroupTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'azureStaticGitHubConfigGroup';
     public contextValue: string = GitHubConfigGroupTreeItem.contextValue;
-    public readonly label: string = localize('gitHubConfig', 'GitHub Configuration');
     public parent: EnvironmentTreeItem;
     public yamlFilePath: string;
     public buildConfigs: BuildConfigs | undefined;
 
-    public constructor(parent: EnvironmentTreeItem, yamlFilePath: string, buildConfigs: BuildConfigs) {
+    public constructor(parent: EnvironmentTreeItem, yamlFilePath: string, buildConfigs: BuildConfigs, public parseYamlError?: unknown) {
         super(parent);
         this.yamlFilePath = yamlFilePath;
         this.buildConfigs = buildConfigs;
         this.id = `${parent.id}-${this.yamlFilePath}`;
+        this.commandArgs = [this];
+    }
+
+    public get label(): string {
+        return this.parseYamlError ? localize('invalidGitHubConfig', 'Invalid GitHub Configuration') : localize('gitHubConfig', 'GitHub Configuration');
+    }
+
+    public get commandId(): string | undefined {
+        return this.parseYamlError ? 'staticWebApps.openYAMLConfigFile' : undefined;
     }
 
     public static async createGitHubConfigGroupTreeItems(context: IActionContext, parent: EnvironmentTreeItem): Promise<GitHubConfigGroupTreeItem[]> {
@@ -49,8 +76,12 @@ export class GitHubConfigGroupTreeItem extends AzExtParentTreeItem {
 
             for (const yamlFile of yamlFiles) {
                 const yamlFilePath: string = join(workflowsDir, yamlFile);
-                const buildConfigs: BuildConfigs | undefined = await parseYamlFile(context, yamlFilePath);
-                buildConfigs && treeItems.push(new GitHubConfigGroupTreeItem(parent, yamlFilePath, buildConfigs));
+                try {
+                    const buildConfigs: BuildConfigs | undefined = await parseYamlFile(context, yamlFilePath);
+                    buildConfigs && treeItems.push(new GitHubConfigGroupTreeItem(parent, yamlFilePath, buildConfigs));
+                } catch (e) {
+                    treeItems.push(new GitHubConfigGroupTreeItem(parent, yamlFilePath, {}, e));
+                }
             }
         }
 
@@ -58,7 +89,7 @@ export class GitHubConfigGroupTreeItem extends AzExtParentTreeItem {
     }
 
     public get iconPath(): TreeItemIconPath {
-        return new ThemeIcon('settings-gear');
+        return this.parseYamlError ? new ThemeIcon('warning') : new ThemeIcon('settings-gear');
     }
 
     public get description(): string {
@@ -69,7 +100,18 @@ export class GitHubConfigGroupTreeItem extends AzExtParentTreeItem {
         return false;
     }
 
+    public get errorRange(): Range | undefined {
+        return this.parseYamlError instanceof YAMLSyntaxError ? getRangeFromError(this.parseYamlError) : undefined;
+    }
+
     public async loadMoreChildrenImpl(): Promise<AzExtTreeItem[]> {
+        if (this.errorRange) {
+            return [new GenericTreeItem(this, {
+                label: getYamlErrorMessage(this.parseYamlError),
+                contextValue: 'parseYamlErrorTreeItem'
+            })];
+        }
+
         const treeItems: GitHubConfigTreeItem[] = [];
 
         for (const buildConfig in this.buildConfigs) {
@@ -81,6 +123,11 @@ export class GitHubConfigGroupTreeItem extends AzExtParentTreeItem {
     }
 
     public async refreshImpl(context: IActionContext): Promise<void> {
-        this.buildConfigs = await parseYamlFile(context, this.yamlFilePath);
+        try {
+            this.buildConfigs = await parseYamlFile(context, this.yamlFilePath);
+            this.parseYamlError = undefined;
+        } catch (e) {
+            this.parseYamlError = e;
+        }
     }
 }

--- a/src/tree/GitHubConfigGroupTreeItem.ts
+++ b/src/tree/GitHubConfigGroupTreeItem.ts
@@ -101,10 +101,13 @@ export class GitHubConfigGroupTreeItem extends AzExtParentTreeItem {
 
     public async loadMoreChildrenImpl(): Promise<AzExtTreeItem[]> {
         if (this.parseYamlError) {
-            return [new GenericTreeItem(this, {
+            const errorTreeItem = new GenericTreeItem(this, {
                 label: getYamlErrorMessage(this.parseYamlError),
-                contextValue: 'parseYamlErrorTreeItem'
-            })];
+                contextValue: 'parseYamlErrorTreeItem',
+                commandId: 'staticWebApps.openYAMLConfigFile'
+            });
+            errorTreeItem.commandArgs = [this];
+            return [errorTreeItem];
         }
 
         const treeItems: GitHubConfigTreeItem[] = [];

--- a/src/utils/yamlUtils.ts
+++ b/src/utils/yamlUtils.ts
@@ -33,7 +33,8 @@ export async function parseYamlFile(context: IActionContext, yamlFilePath: strin
 
 async function getBuildDeployStep(context: IActionContext, yamlFileContents: string, yamlFileName: string): Promise<BuildDeployStep | undefined> {
     if (/Azure\/static-web-apps-deploy/.test(yamlFileContents)) {
-        const parsedYaml = <{ jobs?: { steps?: BuildDeployStep[] }[] }>await parse(yamlFileContents);
+        // prettyErrors option gives range of error. See https://eemeli.org/yaml/v1/#options
+        const parsedYaml = <{ jobs?: { steps?: BuildDeployStep[] }[] }>await parse(yamlFileContents, { prettyErrors: true });
 
         for (const job of Object.values(parsedYaml.jobs || {})) {
             for (const step of Object.values(job.steps || {})) {


### PR DESCRIPTION
Fixes #411 

Clicking on the invalid tree item opens and selects the invalid YAML block.

![image](https://user-images.githubusercontent.com/12476526/129426797-4a7d2a65-b18a-4188-a849-5ceffd1aec68.png)

