### PR TITLE
Change Angular output location default

### DIFF
--- a/src/buildPresets/buildPresets.ts
+++ b/src/buildPresets/buildPresets.ts
@@ -12,7 +12,7 @@ export const buildPresets: IBuildPreset[] = [
         displayName: 'Angular',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocation: 'dist/<Project name>'
+        outputLocation: 'dist/<project-name>'
     },
     {
         id: 'react',

--- a/src/buildPresets/buildPresets.ts
+++ b/src/buildPresets/buildPresets.ts
@@ -12,7 +12,7 @@ export const buildPresets: IBuildPreset[] = [
         displayName: 'Angular',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocation: 'dist'
+        outputLocation: 'dist/<Project name>'
     },
     {
         id: 'react',

--- a/src/buildPresets/buildPresets.ts
+++ b/src/buildPresets/buildPresets.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { angularOutputLocation } from "../constants";
 import { IBuildPreset } from "./IBuildPreset";
 
 // hard-coded defaults for build presets until there is an API that supports this
@@ -12,7 +13,7 @@ export const buildPresets: IBuildPreset[] = [
         displayName: 'Angular',
         appLocation: '/',
         apiLocation: 'api',
-        outputLocation: 'dist/<project-name>'
+        outputLocation: angularOutputLocation
     },
     {
         id: 'react',

--- a/src/commands/createStaticWebApp/OutputLocationStep.ts
+++ b/src/commands/createStaticWebApp/OutputLocationStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep } from "vscode-azureextensionui";
-import { appArtifactSubpathSetting, outputSubpathSetting } from "../../constants";
+import { angularOutputLocation, appArtifactSubpathSetting, outputSubpathSetting } from "../../constants";
 import { localize } from "../../utils/localize";
 import { getWorkspaceSetting } from "../../utils/settingsUtils";
 import { addLocationTelemetry } from "./addLocationTelemetry";
@@ -17,7 +17,13 @@ export class OutputLocationStep extends AzureWizardPromptStep<IStaticWebAppWizar
 
         context.outputLocation = (await context.ui.showInputBox({
             value: workspaceSetting || getWorkspaceSetting(appArtifactSubpathSetting, context.fsPath) || defaultValue,
-            prompt: localize('publishLocation', "Enter the location of your build output relative to your app's location or leave blank if it has no build. For example, setting a value of 'build' when your app location is set to 'app' will cause the content at 'app/build' to be served.")
+            prompt: localize('publishLocation', "Enter the location of your build output relative to your app's location or leave blank if it has no build. For example, setting a value of 'build' when your app location is set to 'app' will cause the content at 'app/build' to be served."),
+            validateInput: (value: string): string | undefined => {
+                if (value === angularOutputLocation) {
+                    return localize('fillProjectName', 'Fill in the name of your Angular project.')
+                }
+                return undefined;
+            }
         })).trim();
 
         addLocationTelemetry(context, 'outputLocation', defaultValue, workspaceSetting);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,8 @@ export const isEndGroup = (t: string): boolean => /##\[endgroup\]/.test(t)
 export const githubAuthProviderId: string = 'github';
 export const githubScopes: string[] = ['repo', 'workflow', 'admin:public_key'];
 
+export const angularOutputLocation = 'dist/<project-name>';
+
 // Source: https://github.com/github/gitignore/blob/master/Node.gitignore
 export const defaultGitignoreContents: string = `# Logs
 logs


### PR DESCRIPTION
This change was suggested last week during standup.

The idea is that the current default `dist/` already breaks most Angular projects if users leave it unchanged. So we're hoping changing it to `dist/<Project name>` helps alert users to change it before deploying.