### PR TITLE
Add location to basic create

### DIFF
--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -58,6 +58,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const executeSteps: AzureWizardExecuteStep<IStaticWebAppWizardContext>[] = [];
 
         if (!context.advancedCreation) {
+            wizardContext.sku = SkuListStep.getSkus()[0];
             executeSteps.push(new ResourceGroupCreateStep());
         } else {
             promptSteps.push(new ResourceGroupListStep());
@@ -72,8 +73,6 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             executeSteps.push(new RepoCreateStep());
         }
 
-        promptSteps.push(new BuildPresetListStep(), new AppLocationStep(), new ApiLocationStep(), new OutputLocationStep());
-
         // hard-coding locations available during preview
         // https://github.com/microsoft/vscode-azurestaticwebapps/issues/18
         const locations = [
@@ -85,17 +84,13 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         ];
 
         const webProvider: string = 'Microsoft.Web';
-        if (context.advancedCreation) {
-            LocationListStep.setLocationSubset(wizardContext, new Promise((resolve) => {
-                resolve(locations);
-            }), webProvider);
+        LocationListStep.setLocationSubset(wizardContext, new Promise((resolve) => {
+            resolve(locations);
+        }), webProvider);
 
-            LocationListStep.addStep(wizardContext, promptSteps);
-        } else {
-            await LocationListStep.setLocation(wizardContext, locations[0]);
-            // default to free for basic
-            wizardContext.sku = SkuListStep.getSkus()[0];
-        }
+        LocationListStep.addStep(wizardContext, promptSteps);
+
+        promptSteps.push(new BuildPresetListStep(), new AppLocationStep(), new ApiLocationStep(), new OutputLocationStep());
 
         executeSteps.push(new VerifyProvidersStep([webProvider]));
         executeSteps.push(new StaticWebAppCreateStep());

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -84,9 +84,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         ];
 
         const webProvider: string = 'Microsoft.Web';
-        LocationListStep.setLocationSubset(wizardContext, new Promise((resolve) => {
-            resolve(locations);
-        }), webProvider);
+        LocationListStep.setLocationSubset(wizardContext, Promise.resolve(locations), webProvider);
 
         LocationListStep.addStep(wizardContext, promptSteps);
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/429

I also moved location to be before all the build preset steps because it felt weird to me to do the Azure prompt (the SWA name) and then do all the prompts that also have location in their name, and _then_ do the physical location.