### PR TITLE
Detect Functions projects and default to that value instead of "api"

### DIFF
--- a/src/commands/createStaticWebApp/ApiLocationStep.ts
+++ b/src/commands/createStaticWebApp/ApiLocationStep.ts
@@ -16,17 +16,21 @@ export class ApiLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardCo
         const defaultValue: string = context.buildPreset?.apiLocation ?? defaultApiLocation;
         const workspaceSetting: string | undefined = getWorkspaceSetting(apiSubpathSetting, context.fsPath);
 
-        context.apiLocation = (await context.ui.showInputBox({
-            value: workspaceSetting || defaultValue,
-            validateInput: (value) => validateLocationYaml(value, 'api_location'),
-            prompt: localize('enterApiLocation', "Enter the location of your Azure Functions code or leave blank to skip this step. For example, 'api' represents a folder called 'api'."),
-        })).trim();
+        context.apiLocation = context.detectedApiLocations ?
+            (await context.ui.showQuickPick(context.detectedApiLocations.map((apiPaths) => { return { label: apiPaths } }), { placeHolder: localize('selectApi', 'Select the location of your Azure Functions code') })).label :
+            (await context.ui.showInputBox({
+                value: workspaceSetting || defaultValue,
+                validateInput: (value) => validateLocationYaml(value, 'api_location'),
+                prompt: localize('enterApiLocation', "Enter the location of your Azure Functions code or leave blank to skip this step. For example, 'api' represents a folder called 'api'."),
+            })).trim();
 
         addLocationTelemetry(context, 'apiLocation', defaultValue, workspaceSetting);
     }
 
     public shouldPrompt(context: IStaticWebAppWizardContext): boolean {
-        if (!context.advancedCreation) {
+        if (context.detectedApiLocations?.length === 1) {
+            context.apiLocation = context.detectedApiLocations[0];
+        } else if (!context.advancedCreation && !context.detectedApiLocations) {
             context.apiLocation = context.buildPreset?.apiLocation ?? defaultApiLocation;
         }
 

--- a/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
+++ b/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
@@ -19,6 +19,8 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext,
 
     repo?: Repository;
     fsPath?: string;
+    // Function projects detected via host.json at SWA create time
+    detectedApiLocations?: string[];
 
     newStaticWebAppName?: string;
 

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -16,6 +16,7 @@ import { showSwaCreated } from '../showSwaCreated';
 import { IStaticWebAppWizardContext } from './IStaticWebAppWizardContext';
 import { postCreateStaticWebApp } from './postCreateStaticWebApp';
 import { setWorkspaceContexts } from './setWorkspaceContexts';
+import { tryGetApiLocations } from './tryGetApiLocations';
 
 export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItem): Promise<StaticWebAppTreeItem> {
     if (!node) {
@@ -30,6 +31,7 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
         const folder = await tryGetWorkspaceFolder(context);
         if (folder) {
             await setWorkspaceContexts(context, folder);
+            context.detectedApiLocations = await tryGetApiLocations(context, folder);
         } else {
             await showNoWorkspacePrompt(context);
         }

--- a/src/commands/createStaticWebApp/tryGetApiLocations.ts
+++ b/src/commands/createStaticWebApp/tryGetApiLocations.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { RelativePattern, workspace, WorkspaceFolder } from "vscode";
+import { IActionContext } from "vscode-azureextensionui";
+import { telemetryUtils } from '../../utils/telemetryUtils';
+
+const hostFileName: string = 'host.json';
+
+/**
+ * Checks root folder and one level down first, then all levels of tree
+ * If a single function project is found, returns that path.
+ * If multiple projects are found, will prompt
+ * @param workspaceFolder Per the VS Code docs for `findFiles`: It is recommended to pass in a workspace folder if the pattern should match inside the workspace.
+ */
+export async function tryGetApiLocations(context: IActionContext, workspaceFolder: WorkspaceFolder | string): Promise<string[] | undefined> {
+    return await telemetryUtils.runWithDurationTelemetry(context, 'tryGetProject', async () => {
+        const folderPath = typeof workspaceFolder === 'string' ? workspaceFolder : workspaceFolder.uri.fsPath;
+        if (await fse.pathExists(folderPath)) {
+            if (await isFunctionProject(folderPath)) {
+                return [folderPath];
+            } else {
+                const hostJsonUris = await workspace.findFiles(new RelativePattern(workspaceFolder, `*/${hostFileName}`));
+                if (hostJsonUris.length !== 1) {
+                    // NOTE: If we found a single project at the root or one level down, we will use that without searching any further.
+                    // This will reduce false positives in the case of compiled languages like C# where a 'host.json' file is often copied to a build/publish directory a few levels down
+                    // It also maintains consistent historical behavior by giving that project priority because we used to _only_ look at the root and one level down
+                    hostJsonUris.push(...await workspace.findFiles(new RelativePattern(workspaceFolder, `*/*/**/${hostFileName}`)));
+                }
+
+                const projectPaths = hostJsonUris.map(uri => path.relative(folderPath, path.dirname(uri.fsPath)));
+                return projectPaths;
+            }
+        }
+
+        return undefined;
+    });
+}
+
+// Use 'host.json' as an indicator that this is a functions project
+async function isFunctionProject(folderPath: string): Promise<boolean> {
+    return await fse.pathExists(path.join(folderPath, hostFileName));
+}

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from 'vscode-azureextensionui';
+
+export namespace telemetryUtils {
+    export async function runWithDurationTelemetry<T>(context: IActionContext, prefix: string, callback: () => Promise<T>): Promise<T> {
+        const start = Date.now();
+        try {
+            return await callback();
+        } finally {
+            const end = Date.now();
+            const durationKey = prefix + 'Duration';
+            const countKey = prefix + 'Count';
+            const duration = (end - start) / 1000;
+
+            context.telemetry.measurements[durationKey] = duration + (context.telemetry.measurements[durationKey] || 0);
+            context.telemetry.measurements[countKey] = 1 + (context.telemetry.measurements[countKey] || 0);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/486

In the case of advanced create, I thought if we detect them projects, we should still default to the one detected or use the quickpick rather than forcing users the manually input the location.  I imagine that the detection logic is pretty reliable, but should we add a "browse" and/or "skip" choice?

I was thinking about it, but my thought process was if they have a functions project in their workspace that they are deploying, then would they really want to skip the step?  And would we really not detect their functions project (that is required to be in the current workspace) that we would actually want to provide them with a "browse" option?