### PR TITLE
Change cancel logic a bit so prevent two messages

### DIFF
--- a/src/commands/github/actionCommands.ts
+++ b/src/commands/github/actionCommands.ts
@@ -57,8 +57,8 @@ export async function checkActionStatus(context: IActionContext, node: ActionTre
 
         workflowRun = (await client.actions.getWorkflowRun({ owner: owner.login, repo: node.data.repository.name, run_id: node.data.id })).data;
         if (ensureStatus(workflowRun) === Status.Completed) {
-            const actionCompleted: string = localize('actionCompleted', 'Action "{0}" has completed with the conclusion "{1}".', node.data.id, workflowRun.conclusion);
             if (!initialCreate) {
+                const actionCompleted: string = localize('actionCompleted', 'Action "{0}" has completed with the conclusion "{1}".', node.data.id, workflowRun.conclusion);
                 ext.outputChannel.appendLog(actionCompleted);
                 void window.showInformationMessage(actionCompleted);
             }

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -50,14 +50,20 @@ export async function pollAsyncOperation(pollingOperation: () => Promise<boolean
             }
 
             pollingComplete = await pollingOperation();
-            await delay(pollIntervalInSeconds * 1000);
+            if (!pollingComplete) {
+                await delay(pollIntervalInSeconds * 1000);
+            }
         }
+
+        return pollingComplete;
     } finally {
-        activeAsyncTokens[id] = undefined;
+        if (!token.isCancellationRequested) {
+            // only clear the token if it wasn't canceled (it gets overwritten with the new one)
+            activeAsyncTokens[id] = undefined;
+        }
+
         tokenSource.dispose();
     }
-
-    return pollingComplete;
 }
 
 //https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations


### PR DESCRIPTION
Fixes #390 

1. Sometimes even when we canceled the token, because the finally always returned `pollingComplete`, if you waited long enough to cancel, it was possible for the re-run to return `true` followed by the cancel to return `true`.
2. I realized that I was clearing the token every time in the finally clause when it should just be when it actually completes (since the cancelled tokenSource is overwritten).  This would cause weird behaviors if you did re-run, cancel, re-run all in sequence, I think.
3. We were delaying even when the polling was complete which was just delaying our notification to the user.  Should be a nicer experience.