### PR TITLE
Add  install/update and uninstall SWA CLI commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "git-url-parse": "^11.1.2",
                 "moment": "^2.27.0",
                 "open": "^8.0.4",
+                "semver": "^7.3.5",
                 "vscode-azureappservice": "^0.86.1",
                 "vscode-azureextensionui": "0.48.3",
                 "vscode-nls": "^4.1.1",
@@ -27,6 +28,7 @@
                 "@types/gulp": "^4.0.6",
                 "@types/mocha": "^8.2.2",
                 "@types/node": "^14.0.0",
+                "@types/semver": "^7.3.8",
                 "@types/vscode": "1.57.0",
                 "@typescript-eslint/eslint-plugin": "^4.28.3",
                 "eslint": "^7.19.0",
@@ -867,6 +869,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/@types/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
+            "dev": true
         },
         "node_modules/@types/source-list-map": {
             "version": "0.1.2",
@@ -6599,7 +6607,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -8877,7 +8884,6 @@
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
             "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -11721,8 +11727,7 @@
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yaml": {
             "version": "1.10.2",
@@ -12754,6 +12759,12 @@
                     }
                 }
             }
+        },
+        "@types/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
+            "dev": true
         },
         "@types/source-list-map": {
             "version": "0.1.2",
@@ -17264,7 +17275,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -18993,7 +19003,6 @@
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
             "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"
             }
@@ -21309,8 +21318,7 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yaml": {
             "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
         "onCommand:staticWebApps.reportIssue",
         "onCommand:staticWebApps.createSwaConfigFile",
         "onCommand:staticWebApps.openGitHubLog",
+        "onCommand:staticWebApps.installOrUpdateStaticWebAppsCli",
+        "onCommand:staticWebApps.uninstallStaticWebAppsCli",
         "onView:staticWebApps"
     ],
     "main": "./main.js",
@@ -210,6 +212,18 @@
                 "command": "staticWebApps.openGitHubLog",
                 "title": "%staticWebApps.openGitHubLog%",
                 "category": "Azure Static Web Apps"
+            },
+            {
+                "command": "staticWebApps.installOrUpdateStaticWebAppsCli",
+                "title": "%staticWebApps.installOrUpdateStaticWebAppsCli%",
+                "category": "Azure Static Web Apps",
+                "enablement": "!virtualWorkspace"
+            },
+            {
+                "command": "staticWebApps.uninstallStaticWebAppsCli",
+                "title": "%staticWebApps.uninstallStaticWebAppsCli%",
+                "category": "Azure Static Web Apps",
+                "enablement": "!virtualWorkspace"
             }
         ],
         "views": {
@@ -424,6 +438,11 @@
                         "scope": "resource",
                         "type": "string",
                         "description": "%staticWebApps.outputSubpath%"
+                    },
+                    "staticWebApps.showStaticWebAppsCliWarning": {
+                        "type": "boolean",
+                        "description": "%staticWebApps.showStaticWebAppsCliWarning%",
+                        "default": true
                     }
                 }
             }
@@ -457,6 +476,7 @@
         "@types/gulp": "^4.0.6",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.0.0",
+        "@types/semver": "^7.3.8",
         "@types/vscode": "1.57.0",
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "eslint": "^7.19.0",
@@ -482,6 +502,7 @@
         "git-url-parse": "^11.1.2",
         "moment": "^2.27.0",
         "open": "^8.0.4",
+        "semver": "^7.3.5",
         "vscode-azureappservice": "^0.86.1",
         "vscode-azureextensionui": "0.48.3",
         "vscode-nls": "^4.1.1",

--- a/package.nls.json
+++ b/package.nls.json
@@ -36,5 +36,8 @@
     "staticWebApps.outputSubpath": "The default value for the location of your build output relative to your application code location",
     "staticWebApps.reportIssue": "Report Issue...",
     "staticWebApps.createSwaConfigFile": "Create Configuration File",
-    "staticWebApps.openGitHubLog": "Open GitHub Action Log"
+    "staticWebApps.openGitHubLog": "Open GitHub Action Log",
+    "staticWebApps.installOrUpdateStaticWebAppsCli": "Install or Update Azure Static Web Apps CLI",
+    "staticWebApps.uninstallStaticWebAppsCli": "Uninstall Azure Static Web Apps CLI",
+    "staticWebApps.showStaticWebAppsCliWarning": "Show a warning if your installed version of the Azure Static Web Apps CLI is out-of-date."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -39,5 +39,5 @@
     "staticWebApps.openGitHubLog": "Open GitHub Action Log",
     "staticWebApps.installOrUpdateStaticWebAppsCli": "Install or Update Azure Static Web Apps CLI",
     "staticWebApps.uninstallStaticWebAppsCli": "Uninstall Azure Static Web Apps CLI",
-    "staticWebApps.showStaticWebAppsCliWarning": "Show a warning if your installed version of the Azure Static Web Apps CLI is out-of-date."
+    "staticWebApps.showStaticWebAppsCliWarning": "Show a warning if the installed version of the Azure Static Web Apps CLI is out-of-date."
 }

--- a/src/commands/cli/getInstalledSwaCliVersion.ts
+++ b/src/commands/cli/getInstalledSwaCliVersion.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as semver from 'semver';
+import { cpUtils } from "../../utils/cpUtils";
+
+export async function getInstalledSwaCliVersion(workingDirectory?: string): Promise<string | null> {
+    try {
+        // npx --global --no-install swa --version
+        // --global makes command only check for globally installed modules
+        // without --global, the command checks locally installed modules first, then globally installed modules
+        // --no-install makes command exit with non-zero exit code if the CLI is not found
+        const output: string = await cpUtils.executeCommand(undefined, workingDirectory, 'npx', '--global', '--no-install', 'swa', '--version');
+        return semver.clean(output);
+    } catch (e) {
+        return null;
+    }
+}

--- a/src/commands/cli/getNewestSwaCliVersion.ts
+++ b/src/commands/cli/getNewestSwaCliVersion.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { HttpOperationResponse } from "@azure/ms-rest-js";
+import { IActionContext, sendRequestWithTimeout } from "vscode-azureextensionui";
+import { swaCliPackageName } from "../../constants";
+import { localize } from "../../utils/localize";
+
+interface IPackageMetadata {
+    "dist-tags": {
+        [tag: string]: string;
+        latest: string;
+    }
+}
+
+export async function getNewestSwaCliVersion(context: IActionContext): Promise<string | undefined> {
+    try {
+        const response: HttpOperationResponse = await sendRequestWithTimeout(context, {
+            method: 'GET',
+            url: `https://registry.npmjs.org/${swaCliPackageName}`
+        }, 15000, undefined);
+        const packageMetadata: IPackageMetadata = <IPackageMetadata>response.parsedBody;
+        return packageMetadata["dist-tags"].latest;
+    } catch (error) {
+        throw new Error(localize('noLatestTag', 'Failed to retrieve then latest version of the Azure Static Web Apps CLI.'));
+    }
+}

--- a/src/commands/cli/installOrUpdateSwaCli.ts
+++ b/src/commands/cli/installOrUpdateSwaCli.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { swaCliPackageName } from "../../constants";
+import { ext } from "../../extensionVariables";
+import { cpUtils } from "../../utils/cpUtils";
+
+export async function installOrUpdateSwaCli(): Promise<void> {
+    ext.outputChannel.show();
+    await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '--global', `${swaCliPackageName}@latest`);
+}

--- a/src/commands/cli/installOrUpdateSwaCli.ts
+++ b/src/commands/cli/installOrUpdateSwaCli.ts
@@ -3,11 +3,16 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from "vscode-azureextensionui";
 import { swaCliPackageName } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { cpUtils } from "../../utils/cpUtils";
+import { localize } from "../../utils/localize";
+import { verifyHasNpm } from "./verifyHasNpm";
 
-export async function installOrUpdateSwaCli(): Promise<void> {
-    ext.outputChannel.show();
-    await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '--global', `${swaCliPackageName}@latest`);
+export async function installOrUpdateSwaCli(context: IActionContext): Promise<void> {
+    if (await verifyHasNpm(context, localize('needNpmToInstall', 'Node.JS and npm are required to install the Azure Static Web Apps CLI'))) {
+        ext.outputChannel.show();
+        await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '--global', `${swaCliPackageName}@latest`);
+    }
 }

--- a/src/commands/cli/uninstallSwaCli.ts
+++ b/src/commands/cli/uninstallSwaCli.ts
@@ -3,18 +3,21 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from "vscode-azureextensionui";
 import { swaCliPackageName } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { cpUtils } from "../../utils/cpUtils";
 import { localize } from "../../utils/localize";
 import { getInstalledSwaCliVersion } from "./getInstalledSwaCliVersion";
+import { verifyHasNpm } from "./verifyHasNpm";
 
-export async function uninstallSwaCli(): Promise<void> {
-    ext.outputChannel.show();
+export async function uninstallSwaCli(context: IActionContext): Promise<void> {
+    if (await verifyHasNpm(context, localize('needNpmToUninstall', 'Node.JS and npm are required to uninstall the Azure Static Web Apps CLI'))) {
+        if (await getInstalledSwaCliVersion() === null) {
+            throw new Error(localize('notInstalled', 'Cannot uninstall Azure Static Web Apps CLI because it is not installed with npm.'));
+        }
 
-    if (await getInstalledSwaCliVersion() === null) {
-        throw new Error(localize('notInstalled', 'Cannot uninstall Azure Static Web Apps CLI because it is not installed with npm.'));
+        ext.outputChannel.show();
+        await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'uninstall', '--global', swaCliPackageName);
     }
-
-    await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'uninstall', '--global', swaCliPackageName);
 }

--- a/src/commands/cli/uninstallSwaCli.ts
+++ b/src/commands/cli/uninstallSwaCli.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { swaCliPackageName } from "../../constants";
+import { ext } from "../../extensionVariables";
+import { cpUtils } from "../../utils/cpUtils";
+import { localize } from "../../utils/localize";
+import { getInstalledSwaCliVersion } from "./getInstalledSwaCliVersion";
+
+export async function uninstallSwaCli(): Promise<void> {
+    ext.outputChannel.show();
+
+    if (await getInstalledSwaCliVersion() === null) {
+        throw new Error(localize('notInstalled', 'Cannot uninstall Azure Static Web Apps CLI because it is not installed.'));
+    }
+
+    await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'uninstall', '--global', swaCliPackageName);
+}

--- a/src/commands/cli/validateSwaCliIsLatest.ts
+++ b/src/commands/cli/validateSwaCliIsLatest.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as semver from 'semver';
+import * as vscode from 'vscode';
+import { callWithTelemetryAndErrorHandling, DialogResponses, IActionContext } from 'vscode-azureextensionui';
+import { cpUtils } from '../../utils/cpUtils';
+import { localize } from '../../utils/localize';
+import { openUrl } from '../../utils/openUrl';
+import { getWorkspaceSetting, updateGlobalSetting } from '../../utils/settingsUtils';
+import { getInstalledSwaCliVersion } from './getInstalledSwaCliVersion';
+import { getNewestSwaCliVersion } from './getNewestSwaCliVersion';
+import { installOrUpdateSwaCli } from './installOrUpdateSwaCli';
+
+const swaCliUrl: string = 'https://aka.ms/installSwaCli';
+
+export async function validateStaticWebAppsCliIsLatest(): Promise<void> {
+    await callWithTelemetryAndErrorHandling('staticWebApps.validateStaticWebAppsCliIsLatest', async (context: IActionContext) => {
+        context.errorHandling.suppressDisplay = true;
+        context.telemetry.properties.isActivationEvent = 'true';
+
+        const showSwaCliWarningKey: string = 'showStaticWebAppsCliWarning';
+        const showSwaCliWarning: boolean = !!getWorkspaceSetting<boolean>(showSwaCliWarningKey);
+
+        if (!await hasNpm()) {
+            return;
+        }
+
+        if (showSwaCliWarning) {
+            const installedVersion: string | null = await getInstalledSwaCliVersion();
+            if (!installedVersion) {
+                return;
+            }
+            context.telemetry.properties.localVersion = installedVersion;
+
+            const newestVersion: string | undefined = await getNewestSwaCliVersion(context);
+            if (!newestVersion) {
+                return;
+            }
+
+            if (semver.major(newestVersion) === semver.major(installedVersion) && semver.gt(newestVersion, installedVersion)) {
+                context.telemetry.properties.outOfDateFunc = 'true';
+                const message: string = localize(
+                    'outdatedSwaCli',
+                    'Update the Azure Static Web Apps CLI ({0}) to the latest ({1}) for the best experience.',
+                    installedVersion,
+                    newestVersion
+                );
+
+                const update: vscode.MessageItem = { title: 'Update' };
+                let result: vscode.MessageItem;
+
+                do {
+                    result = await context.ui.showWarningMessage(message, update, DialogResponses.learnMore, DialogResponses.dontWarnAgain)
+                    if (result === DialogResponses.learnMore) {
+                        await openUrl(swaCliUrl);
+                    } else if (result === update) {
+                        await installOrUpdateSwaCli();
+                    } else if (result === DialogResponses.dontWarnAgain) {
+                        await updateGlobalSetting(showSwaCliWarningKey, false);
+                    }
+                }
+                while (result === DialogResponses.learnMore);
+            }
+        }
+    });
+}
+
+async function hasNpm(): Promise<boolean> {
+    try {
+        await cpUtils.executeCommand(undefined, undefined, 'npm', '--version');
+        return true;
+    } catch (e) {
+        return false;
+    }
+}

--- a/src/commands/cli/validateSwaCliIsLatest.ts
+++ b/src/commands/cli/validateSwaCliIsLatest.ts
@@ -49,7 +49,7 @@ export async function validateStaticWebAppsCliIsLatest(): Promise<void> {
                     newestVersion
                 );
 
-                const update: vscode.MessageItem = { title: 'Update' };
+                const update: vscode.MessageItem = { title: localize('update', 'Update') };
                 let result: vscode.MessageItem;
 
                 do {

--- a/src/commands/cli/verifyHasNpm.ts
+++ b/src/commands/cli/verifyHasNpm.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from "vscode-azureextensionui";
+import { installSwaCliUrl } from "../../constants";
+import { cpUtils } from "../../utils/cpUtils";
+
+export async function verifyHasNpm(context: IActionContext, message?: string): Promise<boolean> {
+    if (await hasNpm()) {
+        return true;
+    }
+
+    if (message) {
+        await context.ui.showWarningMessage(message, {
+            modal: true,
+            learnMoreLink: installSwaCliUrl
+        });
+    }
+
+    return false;
+}
+
+async function hasNpm(): Promise<boolean> {
+    try {
+        await cpUtils.executeCommand(undefined, undefined, 'npm', '--version');
+        return true;
+    } catch (e) {
+        return false;
+    }
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -13,6 +13,8 @@ import { editAppSetting } from './appSettings/editAppSetting';
 import { renameAppSetting } from './appSettings/renameAppSetting';
 import { uploadAppSettings } from './appSettings/uploadAppSettings';
 import { browse } from './browse';
+import { installOrUpdateSwaCli } from './cli/installOrUpdateSwaCli';
+import { uninstallSwaCli } from './cli/uninstallSwaCli';
 import { createChildNode } from './createChildNode';
 import { createHttpFunction } from './createHttpFunction';
 import { createStaticWebApp, createStaticWebAppAdvanced } from './createStaticWebApp/createStaticWebApp';
@@ -58,6 +60,8 @@ export function registerCommands(): void {
     registerCommand('staticWebApps.openYAMLConfigFile', openYAMLConfigFile);
     registerCommand('staticWebApps.createSwaConfigFile', createSwaConfigFile);
     registerCommand('staticWebApps.openGitHubLog', openGitHubLog);
+    registerCommand('staticWebApps.installOrUpdateStaticWebAppsCli', installOrUpdateSwaCli);
+    registerCommand('staticWebApps.uninstallStaticWebAppsCli', uninstallSwaCli);
 
     // Suppress "Report an Issue" button for all errors in favor of the command
     registerErrorHandler(c => c.errorHandling.suppressReportIssue = true);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,6 +33,8 @@ export const githubScopes: string[] = ['repo', 'workflow', 'admin:public_key'];
 
 export const angularOutputLocation = 'dist/<project-name>';
 
+export const swaCliPackageName = '@azure/static-web-apps-cli';
+
 // Source: https://github.com/github/gitignore/blob/master/Node.gitignore
 export const defaultGitignoreContents: string = `# Logs
 logs

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,7 @@ export const githubScopes: string[] = ['repo', 'workflow', 'admin:public_key'];
 export const angularOutputLocation = 'dist/<project-name>';
 
 export const swaCliPackageName = '@azure/static-web-apps-cli';
+export const installSwaCliUrl: string = 'https://aka.ms/installSwaCli';
 
 // Source: https://github.com/github/gitignore/blob/master/Node.gitignore
 export const defaultGitignoreContents: string = `# Logs

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { registerAppServiceExtensionVariables } from 'vscode-azureappservice';
 import { AzExtTreeDataProvider, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, createExperimentationService, IActionContext, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { AzureExtensionApi, AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { revealTreeItem } from './commands/api/revealTreeItem';
+import { validateStaticWebAppsCliIsLatest } from './commands/cli/validateSwaCliIsLatest';
 import { contentScheme } from './commands/github/jobLogs/GitHubLogContentProvider';
 import GitHubLogFoldingProvider from './commands/github/jobLogs/GitHubLogFoldingProvider';
 import { registerCommands } from './commands/registerCommands';
@@ -29,6 +30,8 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     await callWithTelemetryAndErrorHandling('staticWebApps.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
+
+        void validateStaticWebAppsCliIsLatest();
 
         /**
          * By passing `createIfNone: false`, a numbered badge will show up on the accounts activity bar icon.

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, workspace, WorkspaceConfiguration } from "vscode";
+import { ConfigurationTarget, Uri, workspace, WorkspaceConfiguration } from "vscode";
 import { ext } from "../extensionVariables";
 
 /**
@@ -20,4 +20,12 @@ export async function updateWorkspaceSetting<T = string>(section: string, value:
 export function getWorkspaceSetting<T>(key: string, fsPath?: string, prefix: string = ext.prefix): T | undefined {
     const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, fsPath ? Uri.file(fsPath) : undefined);
     return projectConfiguration.get<T>(key);
+}
+
+/**
+ * Uses ext.prefix 'staticWebApps' unless otherwise specified
+ */
+export async function updateGlobalSetting<T = string>(section: string, value: T, prefix: string = ext.prefix): Promise<void> {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
+    await projectConfiguration.update(section, value, ConfigurationTarget.Global);
 }


### PR DESCRIPTION
Note: This is prep work for local debugging features which will depend on the SWA CLI.

Add commands:
* Install or Update Azure Static Web Apps CLI
* Uninstall Azure Static Web Apps CLI

Also checks if the installed CLI version is out of date, and notifies the user to update similarly to Functions with func core tools. It will be important to help users get on the latest version of the SWA CLI because we will be depending on new features for local debugging.

Currently only handles global installations of the CLI.
