### PR TITLE
Add telemetry regarding src folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "vscode-azureappservice": "^0.86.1",
                 "vscode-azureextensionui": "0.48.3",
                 "vscode-nls": "^4.1.1",
+                "vscode-uri": "^3.0.2",
                 "yaml": "^1.10.2"
             },
             "devDependencies": {
@@ -11244,6 +11245,11 @@
                 "node": ">=8.9.3"
             }
         },
+        "node_modules/vscode-uri": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+            "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
+        },
         "node_modules/watchpack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -20954,6 +20960,11 @@
                 "rimraf": "^3.0.2",
                 "unzipper": "^0.10.11"
             }
+        },
+        "vscode-uri": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+            "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
         },
         "watchpack": {
             "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -506,6 +506,7 @@
         "vscode-azureappservice": "^0.86.1",
         "vscode-azureextensionui": "0.48.3",
         "vscode-nls": "^4.1.1",
+        "vscode-uri": "^3.0.2",
         "yaml": "^1.10.2"
     },
     "extensionDependencies": [

--- a/src/detectors/node/nodeConstants.ts
+++ b/src/detectors/node/nodeConstants.ts
@@ -79,4 +79,6 @@ export namespace NodeConstants {
         "three": "Three.js",
         "vue": "Vue.js"
     };
+
+    export const srcFolderName = 'src';
 }


### PR DESCRIPTION
I have a hypothesis that most of our users will not have their app project in the root of the workspace, but have multiple subfolders.  Of those subfolders, I want to check if the subfolder has a "src" folder, and if so, if that subfolder is the app build setting that the user provided.

This has no functional change, it should just be checking for the existence of that folder.