### PR TITLE
Fix backtick typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ There are a couple of ways you can contribute to this repo:
 * **Code**: Contribute bug fixes, features or design changes:
   * Clone the repository locally and open in VS Code.
   * Run "Extensions: Show Recommended Extensions" from the [command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) and install all extensions listed under "Workspace Recommendations"
-  * Open the terminal (press `CTRL+`\`) and run `npm install`.
+  * Open the terminal (press <code>Ctrl + \`</code>) and run `npm install`.
   * To build, press `F1` and type in `Tasks: Run Build Task`.
   * Debug: press `F5` to start debugging the extension.
 


### PR DESCRIPTION
Felt very inspired to fix this

Old:
![image](https://user-images.githubusercontent.com/12476526/135150588-7c32f966-bc44-4893-be10-90011075a139.png)

New:
![image](https://user-images.githubusercontent.com/12476526/135150640-938eceac-206f-4ed4-a6d7-31eae52959fa.png)
