### PR TITLE
Show "Update" or "Install" depending on if SWA CLI is installed

### DIFF
--- a/src/commands/cli/validateSwaCliInstalled.ts
+++ b/src/commands/cli/validateSwaCliInstalled.ts
@@ -57,7 +57,7 @@ export async function validateSwaCliInstalled(context: IActionContext, message: 
     });
 
     // validate that SWA CLI was installed only if user confirmed
-    if (input === install || input === update && !installed) {
+    if ((input === install || input === update) && !installed) {
         await context.ui.showWarningMessage(localize('failedInstallSwaCli', 'The Azure Static Web Apps CLI installation has failed and will have to be installed manually.'), {
             learnMoreLink: installSwaCliUrl
         });


### PR DESCRIPTION
Fixes #547 

And I also fixed a bug I found that showed the "Install failed" notification when it wasn't supposed to.