### PR TITLE
Don't show func tools notification twice

### DIFF
--- a/src/debug/StaticWebAppDebugProvider.ts
+++ b/src/debug/StaticWebAppDebugProvider.ts
@@ -7,10 +7,9 @@ import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, Task
 import { callWithTelemetryAndErrorHandling, IActionContext } from "vscode-azureextensionui";
 import { isSwaCliTask } from "../commands/cli/swaCliTask";
 import { validateSwaCliInstalled } from '../commands/cli/validateSwaCliInstalled';
-import { tryGetApiLocations } from '../commands/createStaticWebApp/tryGetApiLocations';
-import { getFunctionsApi } from '../getExtensionApi';
+import { tryGetApiLocations } from "../commands/createStaticWebApp/tryGetApiLocations";
+import { getFunctionsApi } from "../getExtensionApi";
 import { localize } from '../utils/localize';
-import { AzureFunctionsExtensionApi } from '../vscode-azurefunctions.api';
 
 export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
     public async provideDebugConfigurations(_folder?: WorkspaceFolder, _token?: CancellationToken): Promise<DebugConfiguration[]> {
@@ -34,13 +33,7 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
 
                 const apiLocations = await tryGetApiLocations(context, folder);
                 if (apiLocations?.length) {
-                    // make sure functions core tools is installed
-                    const funcApi: AzureFunctionsExtensionApi = await getFunctionsApi(context);
-                    const message: string = localize('installFuncTools', 'You must have the Azure Functions Core Tools installed to debug your local functions.');
-                    const hasCoreTools: boolean | undefined = await funcApi.validateFuncCoreToolsInstalled(message, folder.uri.fsPath);
-                    if (!hasCoreTools) {
-                        return undefined;
-                    }
+                    await getFunctionsApi(context);
                 }
             }
             return debugConfiguration;

--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -16,7 +16,7 @@ export async function getFunctionsApi(context: IActionContext): Promise<AzureFun
     const funcExtension: AzureExtensionApiProvider | undefined = await getApiExport(funcExtensionId);
 
     if (funcExtension) {
-        return funcExtension.getApi<AzureFunctionsExtensionApi>('^1.5.0');
+        return funcExtension.getApi<AzureFunctionsExtensionApi>('^1.3.0');
     }
 
     await context.ui.showWarningMessage(localize('funcInstall', 'You must have the "Azure Functions" extension installed to perform this operation.'), { title: 'Install', stepName: 'installFunctions' });


### PR DESCRIPTION
Fixes #551 

The cause of this bug was that I was checking for func tools in SWA, but the Functions extension was also checking because it checks whenever a func tools debug configuration resolves.

And as it turns out, the only place I ended up using the `validateFuncCoreToolsInstalled` API from Functions was in the debug config resolver. Removing it fixes the issue and now I guess we can roll back the API changes? I'm not sure.

So this is kinda funny/embarrassing but we ended up not needing the `validateFuncCoreToolsInstalled` method from Functions. 😄 