### PR TITLE
Remove warning for optional step properties

### DIFF
--- a/src/utils/yamlUtils.ts
+++ b/src/utils/yamlUtils.ts
@@ -39,17 +39,11 @@ async function getBuildDeployStep(context: IActionContext, yamlFileContents: str
             for (const step of Object.values(job.steps || {})) {
                 if (step.id === 'builddeploy' && step.with) {
                     const stepIncludesAppLocation: boolean = stepIncludesBuildConfig(step, 'app_location');
-                    const stepIncludesApiLocation: boolean = stepIncludesBuildConfig(step, 'api_location');
-                    const stepIncludesOutputLocation: boolean = stepIncludesBuildConfig(step, 'output_location') || stepIncludesBuildConfig(step, 'app_artifact_location');
 
-                    if (stepIncludesAppLocation && stepIncludesApiLocation && stepIncludesOutputLocation) {
+                    if (stepIncludesAppLocation) {
                         return <BuildDeployStep>step;
                     } else if (!stepIncludesAppLocation) {
                         showYamlWarningMessage(context, yamlFileName, 'app_location');
-                    } else if (!stepIncludesApiLocation) {
-                        showYamlWarningMessage(context, yamlFileName, 'api_location');
-                    } else {
-                        showYamlWarningMessage(context, yamlFileName, 'output_location');
                     }
 
                     // Ignore any other builddeploy steps


### PR DESCRIPTION
Fixes #508 

According to https://docs.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=github-actions#build-and-deploy the only required property is `app_location`. So I removed the warnings for the other properties.

I also verified that the tree nodes work as expected when all the properties aren't present.

![image](https://user-images.githubusercontent.com/12476526/138974273-6d51eedf-e13a-4868-96e7-ae19e7d8ddeb.png)

We could add warning tree nodes and show an invalid state along with the warning we give then `app_location` is missing. Similar to what we did in #476 
