### PR TITLE
Ensure functions is installed when debugging API

### DIFF
--- a/src/debug/StaticWebAppDebugProvider.ts
+++ b/src/debug/StaticWebAppDebugProvider.ts
@@ -65,7 +65,7 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
 
                 if ((await tryGetApiLocations(context, folder))?.length) {
                     // make sure Functions extension is installed
-                    await getFunctionsApi(context);
+                    await getFunctionsApi(context, localize('funcInstallForDebugging', 'You must have the "Azure Functions" extension installed to debug a Functions API.'));
 
                     const configName = this.parseDebugConfigurationName(debugConfiguration);
                     const swaCliConfigFile = await tryGetStaticWebAppsCliConfig(folder.uri);

--- a/src/debug/StaticWebAppDebugProvider.ts
+++ b/src/debug/StaticWebAppDebugProvider.ts
@@ -11,6 +11,7 @@ import { tryGetStaticWebAppsCliConfig } from "../cli/tryGetStaticWebAppsCliConfi
 import { validateSwaCliInstalled } from '../commands/cli/validateSwaCliInstalled';
 import { tryGetApiLocations } from '../commands/createStaticWebApp/tryGetApiLocations';
 import { emulatorAddress, funcAddress, pwaChrome, swaCliConfigFileName } from "../constants";
+import { getFunctionsApi } from '../getExtensionApi';
 import { detectAppFoldersInWorkspace } from "../utils/detectorUtils";
 import { writeFormattedJson } from "../utils/fs";
 import { localize } from '../utils/localize';
@@ -63,6 +64,9 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
                 }
 
                 if ((await tryGetApiLocations(context, folder))?.length) {
+                    // make sure Functions extension is installed
+                    await getFunctionsApi(context);
+
                     const configName = this.parseDebugConfigurationName(debugConfiguration);
                     const swaCliConfigFile = await tryGetStaticWebAppsCliConfig(folder.uri);
 
@@ -85,7 +89,7 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
                 }
             }
 
-            return { ...debugConfiguration, type: 'pwa-chrome' };
+            return debugConfiguration;
         });
     }
 

--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -11,7 +11,10 @@ import { localize } from "./utils/localize";
 import { getWorkspaceSetting } from "./utils/settingsUtils";
 import { AzureFunctionsExtensionApi } from "./vscode-azurefunctions.api";
 
-export async function getFunctionsApi(context: IActionContext): Promise<AzureFunctionsExtensionApi> {
+/**
+ * @param installMessage Override default message shown if extension is not installed.
+ */
+export async function getFunctionsApi(context: IActionContext, installMessage?: string): Promise<AzureFunctionsExtensionApi> {
     const funcExtensionId: string = 'ms-azuretools.vscode-azurefunctions';
     const funcExtension: AzureExtensionApiProvider | undefined = await getApiExport(funcExtensionId);
 
@@ -19,7 +22,7 @@ export async function getFunctionsApi(context: IActionContext): Promise<AzureFun
         return funcExtension.getApi<AzureFunctionsExtensionApi>('^1.3.0');
     }
 
-    await context.ui.showWarningMessage(localize('funcInstall', 'You must have the "Azure Functions" extension installed to perform this operation.'), { title: 'Install', stepName: 'installFunctions' });
+    await context.ui.showWarningMessage(installMessage ?? localize('funcInstall', 'You must have the "Azure Functions" extension installed to perform this operation.'), { title: 'Install', stepName: 'installFunctions' });
     const commandToRun: string = 'extension.open';
     void commands.executeCommand(commandToRun, funcExtensionId);
 


### PR DESCRIPTION
If they don't have it installed it'll prompt them to install it.

Fixes: #549 