### PR TITLE
Add option to shallow search for api locations

### DIFF
--- a/src/cli/SwaCliTaskProvider.ts
+++ b/src/cli/SwaCliTaskProvider.ts
@@ -33,7 +33,7 @@ export class SwaTaskProvider implements TaskProvider {
     private async getTasksFromDetector(context: IActionContext, workspaceFolder: WorkspaceFolder): Promise<Task[]> {
         const tasks: Task[] = [];
 
-        const apiLocations = await tryGetApiLocations(context, workspaceFolder);
+        const apiLocations = await tryGetApiLocations(context, workspaceFolder, true);
 
         const appFolders = await detectAppFoldersInWorkspace(context, workspaceFolder);
         appFolders.forEach((appFolder) => {

--- a/src/commands/createStaticWebApp/tryGetApiLocations.ts
+++ b/src/commands/createStaticWebApp/tryGetApiLocations.ts
@@ -19,7 +19,8 @@ const hostFileName: string = 'host.json';
  * @param shallow Search at the root, and on level down only.
  */
 export async function tryGetApiLocations(context: IActionContext, workspaceFolder: WorkspaceFolder | string, shallow?: boolean): Promise<string[] | undefined> {
-    return await telemetryUtils.runWithDurationTelemetry(context, `tryGetProject${shallow ? 'Shallow' : ''}`, async () => {
+    return await telemetryUtils.runWithDurationTelemetry(context, 'tryGetProject', async () => {
+        context.telemetry.properties.shallow = shallow ? 'true' : 'false';
         const folderPath = typeof workspaceFolder === 'string' ? workspaceFolder : workspaceFolder.uri.fsPath;
         if (await AzExtFsExtra.pathExists(folderPath)) {
             if (await isFunctionProject(folderPath)) {

--- a/src/commands/createStaticWebApp/tryGetApiLocations.ts
+++ b/src/commands/createStaticWebApp/tryGetApiLocations.ts
@@ -16,16 +16,17 @@ const hostFileName: string = 'host.json';
  * If a single function project is found, returns that path.
  * If multiple projects are found, will prompt
  * @param workspaceFolder Per the VS Code docs for `findFiles`: It is recommended to pass in a workspace folder if the pattern should match inside the workspace.
+ * @param shallow Search at the root, and on level down only.
  */
-export async function tryGetApiLocations(context: IActionContext, workspaceFolder: WorkspaceFolder | string): Promise<string[] | undefined> {
-    return await telemetryUtils.runWithDurationTelemetry(context, 'tryGetProject', async () => {
+export async function tryGetApiLocations(context: IActionContext, workspaceFolder: WorkspaceFolder | string, shallow?: boolean): Promise<string[] | undefined> {
+    return await telemetryUtils.runWithDurationTelemetry(context, `tryGetProject${shallow ? 'Shallow' : ''}`, async () => {
         const folderPath = typeof workspaceFolder === 'string' ? workspaceFolder : workspaceFolder.uri.fsPath;
         if (await AzExtFsExtra.pathExists(folderPath)) {
             if (await isFunctionProject(folderPath)) {
                 return [folderPath];
             } else {
                 const hostJsonUris = await workspace.findFiles(new RelativePattern(workspaceFolder, `*/${hostFileName}`));
-                if (hostJsonUris.length !== 1) {
+                if (hostJsonUris.length !== 1 && !shallow) {
                     // NOTE: If we found a single project at the root or one level down, we will use that without searching any further.
                     // This will reduce false positives in the case of compiled languages like C# where a 'host.json' file is often copied to a build/publish directory a few levels down
                     // It also maintains consistent historical behavior by giving that project priority because we used to _only_ look at the root and one level down

--- a/src/debug/StaticWebAppDebugProvider.ts
+++ b/src/debug/StaticWebAppDebugProvider.ts
@@ -63,7 +63,7 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
                     return undefined;
                 }
 
-                if ((await tryGetApiLocations(context, folder))?.length) {
+                if ((await tryGetApiLocations(context, folder, true))?.length) {
                     // make sure Functions extension is installed
                     await getFunctionsApi(context, localize('funcInstallForDebugging', 'You must have the "Azure Functions" extension installed to debug a Functions API.'));
 


### PR DESCRIPTION
Using this in resolve debug config and the task provider because we need to be cautious of long running async calls. And tryGetApiLocation could run for tens of seconds sometimes if we search through a large workspace.