### PR TITLE
Add postfix to debug configs

### DIFF
--- a/src/debug/StaticWebAppDebugProvider.ts
+++ b/src/debug/StaticWebAppDebugProvider.ts
@@ -31,7 +31,7 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
 
             const swaCliConfigFile = await tryGetStaticWebAppsCliConfig(folder.uri);
             if (swaCliConfigFile) {
-                result.push(...Object.entries(swaCliConfigFile?.configurations ?? []).map(([name, options]) => this.createDebugConfiguration(name, options.appLocation)));
+                result.push(...Object.entries(swaCliConfigFile?.configurations ?? []).map(([name, options]) => this.createDebugConfiguration(name, options.appLocation, swaCliConfigFileName)));
             }
 
             const appFolders = await detectAppFoldersInWorkspace(context, folder);
@@ -102,9 +102,9 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
         });
     }
 
-    private createDebugConfiguration(name: string, appLocation: string = ''): DebugConfiguration {
+    private createDebugConfiguration(name: string, appLocation: string = '', postfix?: string): DebugConfiguration {
         return {
-            name: `${StaticWebAppDebugProvider.configPrefix}${name}`,
+            name: `${StaticWebAppDebugProvider.configPrefix}${name}${postfix ? ` (${postfix})` : ''}`,
             request: 'launch',
             type: pwaChrome,
             url: emulatorAddress,


### PR DESCRIPTION
Option A postfixing both:

![image](https://user-images.githubusercontent.com/12476526/140234651-7118de2d-055a-4d9e-9ccd-f3eaa2115dbe.png)

Option B: postfixing only the ones picked up from the swa-cli.config.json file

![image](https://user-images.githubusercontent.com/12476526/140234744-3f8309e8-8b6d-4814-9519-56cb6728c79f.png)

I went with option B because A looked really busy but I'm open to feedback.