### PR TITLE
Add devserver-timeout flag to SWA CLI tasks

### DIFF
--- a/src/cli/SwaCliTaskProvider.ts
+++ b/src/cli/SwaCliTaskProvider.ts
@@ -92,6 +92,9 @@ export class SwaTaskProvider implements TaskProvider {
         };
 
         const args: string[] = [addArg(options, 'appLocation', 'app-location'), addArg(options, 'apiLocation', 'api-location'), addArg(options, 'run', 'run', true)];
+
+        // Increase devserver timeout to 3x default. See https://github.com/microsoft/vscode-azurestaticwebapps/issues/574#issuecomment-965590774
+        args.push('--devserver-timeout=90000');
         const command = `swa start ${options.context} ${args.join(' ')}`;
         const task = new Task(
             {


### PR DESCRIPTION
Fixes #574

I'd like at least @wwlorey to verify that this works since he can repro #574 

I think setting the timeout to 90000 ms (90 seconds) is ok since it's 3x the default of 30000, but nothing else went into that choice.