### PR TITLE
Fix Chrome not opening when debugging by increasing the timeout

### DIFF
--- a/src/debug/StaticWebAppDebugProvider.ts
+++ b/src/debug/StaticWebAppDebugProvider.ts
@@ -111,7 +111,10 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
             type: pwaChrome,
             url: emulatorAddress,
             preLaunchTask: `swa: start ${name}`,
-            webRoot: `\${workspaceFolder}/${appLocation}`
+            webRoot: `\${workspaceFolder}/${appLocation}`,
+            // Ensure the debugger waits long enough for the emulator to start
+            // See https://github.com/microsoft/vscode-azurestaticwebapps/issues/570
+            timeout: 30000
         };
     }
 

--- a/test/debugProvider.test.ts
+++ b/test/debugProvider.test.ts
@@ -20,6 +20,7 @@ const testCases: ITestCase[] = [
             {
                 "name": "SWA: Run react-basic",
                 "request": "launch",
+                "timeout": 30000,
                 "type": "pwa-chrome",
                 "url": "http://localhost:4280",
                 "preLaunchTask": "swa: start react-basic",
@@ -33,6 +34,7 @@ const testCases: ITestCase[] = [
             {
                 "name": "SWA: Run angular-basic",
                 "request": "launch",
+                "timeout": 30000,
                 "type": "pwa-chrome",
                 "url": "http://localhost:4280",
                 "preLaunchTask": "swa: start angular-basic",
@@ -46,6 +48,7 @@ const testCases: ITestCase[] = [
             {
                 "name": "SWA: Run app (swa-cli.config.json)",
                 "request": "launch",
+                "timeout": 30000,
                 "type": "pwa-chrome",
                 "url": "http://localhost:4280",
                 "preLaunchTask": "swa: start app",


### PR DESCRIPTION
Fixes #570 

Fixes issue on slower computers, Chrome might never launch if the emulator takes too long to start.

I've verified this myself using [20211111.6](https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=40798&view=results) on the testers Ubuntu VM.

I'm hardcoding this also because this is easily changed by customizing the launch.json.

edit: Thank you @v-xinda for being so helpful, wouldn't have caught/fixed this without you! 
