### PR TITLE
Turn on "strict" tsconfig rule

### DIFF
--- a/src/detectors/node/NodeDetector.ts
+++ b/src/detectors/node/NodeDetector.ts
@@ -144,7 +144,7 @@ export class NodeDetector {
             const devDependencies = packageJson.devDependencies;
             for (const framework of Object.keys(NodeConstants.DevDependencyFrameworkKeyWordToName)) {
                 if (devDependencies[framework]) {
-                    detectedFrameworkResult.push({ framework: <string>NodeConstants.DevDependencyFrameworkKeyWordToName[framework], version: devDependencies[framework] })
+                    detectedFrameworkResult.push({ framework: NodeConstants.DevDependencyFrameworkKeyWordToName[framework as keyof typeof NodeConstants.DevDependencyFrameworkKeyWordToName], version: devDependencies[framework] })
                 }
             }
         }
@@ -153,7 +153,7 @@ export class NodeDetector {
             const dependencies = packageJson.dependencies;
             for (const framework of Object.keys(NodeConstants.DependencyFrameworkKeyWordToName)) {
                 if (dependencies[framework]) {
-                    detectedFrameworkResult.push({ framework: <string>NodeConstants.DependencyFrameworkKeyWordToName[framework], version: dependencies[framework] })
+                    detectedFrameworkResult.push({ framework: NodeConstants.DependencyFrameworkKeyWordToName[framework as keyof typeof NodeConstants.DependencyFrameworkKeyWordToName], version: dependencies[framework] })
                 }
             }
         }

--- a/src/tree/ActionTreeItem.ts
+++ b/src/tree/ActionTreeItem.ts
@@ -18,7 +18,7 @@ import { JobTreeItem } from './JobTreeItem';
 export class ActionTreeItem extends AzExtParentTreeItem implements IAzureResourceTreeItem {
     public static contextValueCompleted: string = 'azureStaticActionCompleted';
     public static contextValueInProgress: string = 'azureStaticActionInProgress';
-    public parent: ActionsTreeItem;
+    public parent!: ActionsTreeItem;
     public childTypeLabel: string = localize('job', 'job');
     public data: ActionsGetWorkflowRunResponseData;
 

--- a/src/tree/ActionsTreeItem.ts
+++ b/src/tree/ActionsTreeItem.ts
@@ -19,7 +19,7 @@ export class ActionsTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'azureStaticActions';
     public readonly contextValue: string = ActionsTreeItem.contextValue;
     public readonly childTypeLabel: string = localize('action', 'action');
-    public parent: EnvironmentTreeItem;
+    public parent!: EnvironmentTreeItem;
 
     constructor(parent: EnvironmentTreeItem) {
         super(parent);

--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -33,11 +33,11 @@ export class EnvironmentTreeItem extends AzExtParentTreeItem implements IAzureRe
     public static contextValue: string = 'azureStaticEnvironment';
     public readonly contextValue: string = EnvironmentTreeItem.contextValue;
 
-    public parent: StaticWebAppTreeItem;
+    public parent!: StaticWebAppTreeItem;
     public data: WebSiteManagementModels.StaticSiteBuildARMResource;
 
-    public actionsTreeItem: ActionsTreeItem;
-    public gitHubConfigGroupTreeItems: WorkflowGroupTreeItem[];
+    public actionsTreeItem!: ActionsTreeItem;
+    public gitHubConfigGroupTreeItems!: WorkflowGroupTreeItem[];
     public appSettingsTreeItem?: AppSettingsTreeItem;
     public functionsTreeItem?: FunctionsTreeItem;
 
@@ -49,7 +49,7 @@ export class EnvironmentTreeItem extends AzExtParentTreeItem implements IAzureRe
     public localProjectPath: string | undefined;
 
     public isProduction: boolean;
-    public inWorkspace: boolean;
+    public inWorkspace!: boolean;
 
     constructor(parent: StaticWebAppTreeItem, env: WebSiteManagementModels.StaticSiteBuildARMResource) {
         super(parent);

--- a/src/tree/JobTreeItem.ts
+++ b/src/tree/JobTreeItem.ts
@@ -17,7 +17,7 @@ import { StepTreeItem } from './StepTreeItem';
 export class JobTreeItem extends AzExtParentTreeItem implements IAzureResourceTreeItem {
     public static contextValue: string = 'azureStaticJob';
     public readonly contextValue: string = JobTreeItem.contextValue;
-    public parent: ActionTreeItem;
+    public parent!: ActionTreeItem;
     public childTypeLabel: string = localize('step', 'step');
     public data: ActionsGetJobForWorkflowRunResponseData;
 

--- a/src/tree/StepTreeItem.ts
+++ b/src/tree/StepTreeItem.ts
@@ -12,7 +12,7 @@ import { JobTreeItem } from './JobTreeItem';
 export class StepTreeItem extends AzExtTreeItem implements IAzureResourceTreeItem {
     public static contextValue: string = 'azureStaticStep';
     public readonly contextValue: string = StepTreeItem.contextValue;
-    public parent: JobTreeItem;
+    public parent!: JobTreeItem;
     public data: ActionWorkflowStepData;
 
     constructor(parent: JobTreeItem, data: ActionWorkflowStepData) {

--- a/src/tree/WorkflowGroupTreeItem.ts
+++ b/src/tree/WorkflowGroupTreeItem.ts
@@ -42,7 +42,7 @@ function getYamlErrorMessage(error: unknown): string {
 export class WorkflowGroupTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'azureStaticWorkflowGroup';
     public contextValue: string = WorkflowGroupTreeItem.contextValue;
-    public parent: EnvironmentTreeItem;
+    public parent!: EnvironmentTreeItem;
     public yamlFilePath: string;
     public buildConfigs: BuildConfigs | undefined;
     public parseYamlError: unknown;
@@ -112,7 +112,7 @@ export class WorkflowGroupTreeItem extends AzExtParentTreeItem {
         const treeItems: WorkflowTreeItem[] = [];
 
         for (const buildConfig in this.buildConfigs) {
-            const value: string | undefined = <string | undefined>this.buildConfigs[buildConfig];
+            const value: string | undefined = <string | undefined>this.buildConfigs[buildConfig as keyof BuildConfigs];
             value !== undefined && treeItems.push(new WorkflowTreeItem(this, <BuildConfig>buildConfig, value));
         }
 

--- a/src/tree/WorkflowTreeItem.ts
+++ b/src/tree/WorkflowTreeItem.ts
@@ -14,7 +14,7 @@ export class WorkflowTreeItem extends AzExtTreeItem {
     public commandArgs: unknown[];
     public readonly buildConfig: string;
     public buildConfigValue: string;
-    public parent: WorkflowGroupTreeItem;
+    public parent!: WorkflowGroupTreeItem;
 
     public constructor(parent: WorkflowGroupTreeItem, buildConfig: BuildConfig, buildConfigValue: string) {
         super(parent);

--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -19,7 +19,7 @@ import { nonNullProp } from './nonNull';
  * @param description Optional property of JSON that will be used as QuickPicks description
  * @param data Optional property of JSON that will be used as QuickPicks data saved as a NameValue pair
  */
-export function createQuickPickFromJsons<T>(data: T[], label: string): IAzureQuickPickItem<T>[] {
+export function createQuickPickFromJsons<T>(data: T[], label: keyof T): IAzureQuickPickItem<T>[] {
     const quickPicks: IAzureQuickPickItem<T>[] = [];
 
     for (const d of data) {
@@ -29,7 +29,7 @@ export function createQuickPickFromJsons<T>(data: T[], label: string): IAzureQui
         }
 
         quickPicks.push({
-            label: <string>d[label],
+            label: d[label] as unknown as string,
             data: d
         });
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "lib": [
             "es6"
         ],
+        "strict": true,
         "sourceMap": true,
         "rootDir": ".",
         "noUnusedLocals": true,


### PR DESCRIPTION
Had to make a few types-only changes, most of them are just informing TS that we set `parent` in the super constructor using the `!`.