### PR TITLE
Fix error when checking if debug config is SWA

### DIFF
--- a/src/debug/StaticWebAppDebugProvider.ts
+++ b/src/debug/StaticWebAppDebugProvider.ts
@@ -140,6 +140,6 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
     }
 
     private isSwaDebugConfig(debugConfiguration: DebugConfiguration): boolean {
-        return debugConfiguration?.name?.startsWith(StaticWebAppDebugProvider.configPrefix);
+        return !!(debugConfiguration?.name?.startsWith(StaticWebAppDebugProvider.configPrefix));
     }
 }

--- a/src/debug/StaticWebAppDebugProvider.ts
+++ b/src/debug/StaticWebAppDebugProvider.ts
@@ -140,6 +140,6 @@ export class StaticWebAppDebugProvider implements DebugConfigurationProvider {
     }
 
     private isSwaDebugConfig(debugConfiguration: DebugConfiguration): boolean {
-        return debugConfiguration.name.startsWith(StaticWebAppDebugProvider.configPrefix);
+        return debugConfiguration?.name?.startsWith(StaticWebAppDebugProvider.configPrefix);
     }
 }


### PR DESCRIPTION
Telemetry is showing that this method is being called with lots of `debugConfiguration`s that have no name property. Which is throwing an error when we do `debugConfiguration.name.startsWith`. I was tempted to suppress all telemetry until after that check, but I am afraid I might miss other errors if I did that.