### PR TITLE
Fix single quotes to double quotes for windows

### DIFF
--- a/src/cli/SwaCliTaskProvider.ts
+++ b/src/cli/SwaCliTaskProvider.ts
@@ -88,7 +88,7 @@ export class SwaTaskProvider implements TaskProvider {
     private createSwaCliTask(workspaceFolder: WorkspaceFolder, label: string, options: Pick<SWACLIOptions, 'context' | 'apiLocation' | 'run' | 'appLocation'>): Task {
 
         const addArg = <T>(object: T, property: keyof T, name?: string, quote?: boolean): string => {
-            return object[property] ? quote ? `--${name ?? property.toString()}='${object[property]}'` : `--${name ?? property.toString()}=${object[property]}` : '';
+            return object[property] ? quote ? `--${name ?? property.toString()}=\"${object[property]}\"` : `--${name ?? property.toString()}=${object[property]}` : '';
         };
 
         const args: string[] = [addArg(options, 'appLocation', 'app-location'), addArg(options, 'apiLocation', 'api-location'), addArg(options, 'run', 'run', true)];


### PR DESCRIPTION
In windows,  `SWA: Run my-static-web-apps` failed. 
The console output is as follows.
--run option's value is not recognized correctly.
```
> Executing task: swa start http://localhost:8080  --api-location=http://localhost:7071 --run='npm run serve' --devserver-timeout=90000 <
[run] ''npm' is not recognized as an internal or external command,
[run] operable program or batch file.
[run] cd "C:\my-static-web-apps\" && 'npm exited with code 1
[swa] - Waiting for http://localhost:8080 to be ready
```

I changed single quotes to double quotes in `createSwaCliTask()` in SwaCliTaskProvider.ts, it works fine in windows.
```
> Executing task: swa start http://localhost:8080  --api-location=http://localhost:7071 --run="npm run serve" --devserver-timeout=90000 <
[run] 
[run] > hello@0.1.0 serve C:\my-static-web-apps
[run] > vue-cli-service serve
[run]
[swa] - Waiting for http://localhost:8080 to be ready
```
