### PR TITLE
Handle reserved app settings prefixes

### DIFF
--- a/src/commands/appSettings/uploadAppSettings.ts
+++ b/src/commands/appSettings/uploadAppSettings.ts
@@ -5,6 +5,7 @@
 
 import { AppSettingsTreeItem, IAppSettingsClient } from 'vscode-azureappservice';
 import { IActionContext } from "vscode-azureextensionui";
+import { reservedSettingsPrefixes } from '../../constants';
 import { ext } from "../../extensionVariables";
 import { getFunctionsApi } from '../../getExtensionApi';
 import { localize } from "../../utils/localize";
@@ -19,6 +20,6 @@ export async function uploadAppSettings(context: IActionContext, node?: AppSetti
 
     const client: IAppSettingsClient = await node.clientProvider.createClient(context);
     await node.runWithTemporaryDescription(context, localize('uploading', 'Uploading...'), async () => {
-        await funcApi.uploadAppSettings(client);
+        await funcApi.uploadAppSettings(client, reservedSettingsPrefixes);
     });
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,9 @@ export const shell: string = 'shell';
 export const minSwaCliVersion = '0.8.0';
 export const swaCliConfigFileName = 'swa-cli.config.json';
 
+// https://docs.microsoft.com/en-us/azure/static-web-apps/apis#constraints
+export const reservedSettingsPrefixes: (RegExp | string)[] = [/^APPSETTING_/, /^AZUREBLOBSTORAGE_/, /^AZUREFILESSTORAGE_/, /^AZURE_FUNCTION_/, /^CONTAINER_/, /^DIAGNOSTICS_/, /^DOCKER_/, /^FUNCTIONS_/, /^IDENTITY_/, /^MACHINEKEY_/, /^MAINSITE_/, /^MSDEPLOY_/, /^SCMSITE_/, /^SCM_/, /^WEBSITES_/, /^WEBSITE_/, /^WEBSOCKET_/, /^AzureWeb/];
+
 export const gitignoreFileName = '.gitignore';
 
 // Source: https://github.com/github/gitignore/blob/master/Node.gitignore

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -10,7 +10,7 @@ export interface AzureFunctionsExtensionApi {
 
     createFunction(options: ICreateFunctionOptions): Promise<void>;
     downloadAppSettings(client: IAppSettingsClient): Promise<void>;
-    uploadAppSettings(client: IAppSettingsClient): Promise<void>;
+    uploadAppSettings(client: IAppSettingsClient, exclude?: (RegExp | string)[]): Promise<void>;
 }
 
 export type ProjectLanguage = 'JavaScript' | 'TypeScript' | 'C#' | 'Python' | 'PowerShell' | 'Java';


### PR DESCRIPTION
Depends on https://github.com/microsoft/vscode-azurefunctions/pull/3032
Fixes #509 

Excludes app settings that have reserved prefixes from being uploaded. 
https://docs.microsoft.com/en-us/azure/static-web-apps/apis#constraints