### PR TITLE
Bump required vscode version to 1.62.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "webpack-cli": "^4.6.0"
             },
             "engines": {
-                "vscode": "^1.57.0"
+                "vscode": "^1.62.1"
             }
         },
         "node_modules/@azure/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/azure-staticwebapps.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.57.0"
+        "vscode": "^1.62.1"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
The debugging work added in [`v0.9.0`](https://github.com/microsoft/vscode-azurestaticwebapps/releases/tag/v0.9.0) depends on [a fix](https://github.com/microsoft/vscode/issues/135899) that was released in `1.62.1`, now that VS Code is on `1.63.x` we should be good to bump this.

Fixes #579