### PR TITLE
Bump @types/vscode to 1.62.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "@types/mocha": "^8.2.2",
                 "@types/node": "^14.0.0",
                 "@types/semver": "^7.3.8",
-                "@types/vscode": "1.57.0",
+                "@types/vscode": "1.62.0",
                 "@typescript-eslint/eslint-plugin": "^4.28.3",
                 "eslint": "^7.19.0",
                 "eslint-plugin-import": "^2.22.1",
@@ -947,9 +947,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-            "integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
+            "integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
             "dev": true
         },
         "node_modules/@types/webpack": {
@@ -12715,9 +12715,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-            "integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
+            "integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
             "dev": true
         },
         "@types/webpack": {

--- a/package.json
+++ b/package.json
@@ -512,7 +512,7 @@
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.0.0",
         "@types/semver": "^7.3.8",
-        "@types/vscode": "1.57.0",
+        "@types/vscode": "1.62.0",
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "eslint": "^7.19.0",
         "eslint-plugin-import": "^2.22.1",


### PR DESCRIPTION
We bumped the vscode version, but forgot to bump the @types version. 

Thanks Nathan for reminding me https://github.com/microsoft/vscode-azurestaticwebapps/pull/602#pullrequestreview-849828770