### PR TITLE
Don't wait for resource group to delete after deleting static web app

### DIFF
--- a/src/tree/StaticWebAppTreeItem.ts
+++ b/src/tree/StaticWebAppTreeItem.ts
@@ -104,7 +104,7 @@ export class StaticWebAppTreeItem extends AzExtParentTreeItem implements IAzureR
             ext.outputChannel.appendLog(deleteSucceeded);
 
             if (resources.length === 1) {
-                await resourceClient.resourceGroups.beginDeleteAndWait(this.resourceGroup);
+                await resourceClient.resourceGroups.beginDelete(this.resourceGroup);
             }
         });
     }


### PR DESCRIPTION
Mistakenly changed the behavior to wait when upgrading SDK. This changes it back to match the correct behavior (delete RG in background)