### PR TITLE
Add Next.JS build presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurestaticwebapps",
-    "version": "0.10.1-alpha.1",
+    "version": "0.10.1-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurestaticwebapps",
-            "version": "0.10.1-alpha.1",
+            "version": "0.10.1-alpha.2",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurestaticwebapps",
     "displayName": "Azure Static Web Apps",
     "description": "%staticWebApps.description%",
-    "version": "0.10.1-alpha.1",
+    "version": "0.10.1-alpha.2",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-staticwebapps.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/buildPresets/buildPresets.ts
+++ b/src/buildPresets/buildPresets.ts
@@ -61,7 +61,7 @@ export const buildPresets: IBuildPreset[] = [
     },
     {
         id: 'nextjs',
-        displayName: 'Next.JS (SSR)',
+        displayName: 'Next.js (SSR)',
         appLocation: '/',
         apiLocation: '',
         outputLocation: '',
@@ -70,7 +70,7 @@ export const buildPresets: IBuildPreset[] = [
     },
     {
         id: 'nextjs-export',
-        displayName: 'Next.JS (static export)',
+        displayName: 'Next.js (static export)',
         appLocation: '/',
         apiLocation: '',
         outputLocation: 'out',

--- a/src/buildPresets/buildPresets.ts
+++ b/src/buildPresets/buildPresets.ts
@@ -68,6 +68,15 @@ export const buildPresets: IBuildPreset[] = [
         port: 3000,
         group: 'framework'
     },
+    {
+        id: 'nextjs-export',
+        displayName: 'Next.JS (static export)',
+        appLocation: '/',
+        apiLocation: '',
+        outputLocation: 'out',
+        port: 3000,
+        group: 'framework'
+    },
 
     {
         id: 'gatsby',
@@ -94,15 +103,6 @@ export const buildPresets: IBuildPreset[] = [
         apiLocation: 'api',
         outputLocation: '.vuepress/dist',
         port: 8080,
-        group: 'ssg'
-    },
-    {
-        id: 'nextjs',
-        displayName: 'Next.JS (static export)',
-        appLocation: '/',
-        apiLocation: '',
-        outputLocation: 'out',
-        port: 3000,
         group: 'ssg'
     }
 ];

--- a/src/buildPresets/buildPresets.ts
+++ b/src/buildPresets/buildPresets.ts
@@ -59,6 +59,15 @@ export const buildPresets: IBuildPreset[] = [
         group: 'framework'
 
     },
+    {
+        id: 'nextjs',
+        displayName: 'Next.JS (SSR)',
+        appLocation: '/',
+        apiLocation: '',
+        outputLocation: '',
+        port: 3000,
+        group: 'framework'
+    },
 
     {
         id: 'gatsby',
@@ -85,6 +94,15 @@ export const buildPresets: IBuildPreset[] = [
         apiLocation: 'api',
         outputLocation: '.vuepress/dist',
         port: 8080,
+        group: 'ssg'
+    },
+    {
+        id: 'nextjs',
+        displayName: 'Next.JS (static export)',
+        appLocation: '/',
+        apiLocation: '',
+        outputLocation: 'out',
+        port: 3000,
         group: 'ssg'
     }
 ];


### PR DESCRIPTION
Closes #612

As @simonaco presents in #612, Next.JS has two ways to create your app: 
1. the standard way, which includes server-side rendering (SSR). This bundles a custom express.js server into your app as an api
2. static export, which doesn't support SSR, and exports as, as the name implies, static html + js + css

We can add these both as different presets to make it easy for users, and I think this would be a good way to show them:

![image](https://user-images.githubusercontent.com/12476526/163608944-b122b3c3-d44d-4d80-a462-6c1dc79dbe1e.png)

