### PR TITLE
Get all workflowruns and filter based off branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurestaticwebapps",
-    "version": "0.10.1-alpha.1",
+    "version": "0.10.1-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurestaticwebapps",
-            "version": "0.10.1-alpha.1",
+            "version": "0.10.1-alpha.2",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurestaticwebapps",
     "displayName": "Azure Static Web Apps",
     "description": "%staticWebApps.description%",
-    "version": "0.10.1-alpha.1",
+    "version": "0.10.1-alpha.2",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-staticwebapps.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/tree/ActionsTreeItem.ts
+++ b/src/tree/ActionsTreeItem.ts
@@ -46,10 +46,11 @@ export class ActionsTreeItem extends AzExtParentTreeItem {
         const branch: string = this.parent.branch;
 
         const octokitClient: Octokit = await createOctokitClient(context);
-        const response: OctokitResponse<ActionsListWorkflowRunsForRepoResponseData> = await octokitClient.actions.listWorkflowRunsForRepo({ owner: owner, repo: name, branch: branch });
+        const response: OctokitResponse<ActionsListWorkflowRunsForRepoResponseData> = await octokitClient.actions.listWorkflowRunsForRepo({ owner: owner, repo: name });
+        const runs = response.data.workflow_runs.filter(run => run.head_branch === branch);
 
         return await this.createTreeItemsWithErrorHandling(
-            response.data.workflow_runs,
+            runs,
             'invalidActionTreeItem',
             (act) => new ActionTreeItem(this, act),
             act => act.head_commit?.message


### PR DESCRIPTION
After some investigation, seems like new repos don't support branch as a query param (it returns with an empty array).  I'm not surprised since GitHub itself doesn't have a view to only look at actions based on branch, so I think it makes more sense to just grab all the actions and filter based off the branch instead.