### PR TITLE
Remove bad semver check to fix CLI update notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurestaticwebapps",
-    "version": "0.11.1-alpha.1",
+    "version": "0.11.1-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurestaticwebapps",
-            "version": "0.11.1-alpha.1",
+            "version": "0.11.1-alpha.2",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurestaticwebapps",
     "displayName": "Azure Static Web Apps",
     "description": "%staticWebApps.description%",
-    "version": "0.11.1-alpha.1",
+    "version": "0.11.1-alpha.2",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-staticwebapps.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/commands/cli/validateSwaCliIsLatest.ts
+++ b/src/commands/cli/validateSwaCliIsLatest.ts
@@ -41,7 +41,7 @@ export async function validateStaticWebAppsCliIsLatest(): Promise<void> {
                 return;
             }
 
-            if (semver.major(newestVersion) === semver.major(installedVersion) && semver.gt(newestVersion, installedVersion)) {
+            if (semver.gt(newestVersion, installedVersion)) {
                 context.telemetry.properties.outOfDateSwaCli = 'true';
                 const message: string = localize(
                     'outdatedSwaCli',


### PR DESCRIPTION
1. This check currently prevents the notification to update the CLI from appearing if the installed version and the newest version don't have the same major version number 🤦 .
2. The logic was most likely [copied from here in Functions](https://github.com/microsoft/vscode-azurefunctions/blob/411ece5f9453af075c1ff48c70aec349f5942a47/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts#L79), and shouldn't be needed for SWA. Func core tools follows a different versioning method, but the SWA CLI follows semver.
3. Should increase the % of users on v1 of the CLI, which will allow us to remove/improve a lot of code.