### PR TITLE
Add Action to create version bump PR after releasing

### DIFF
--- a/.github/workflows/bump-version-pr.yaml
+++ b/.github/workflows/bump-version-pr.yaml
@@ -1,0 +1,30 @@
+name: Bump version after release
+
+# Run when release is published, or manually triggered
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Bump version
+        id: bump
+        uses: alexweininger/bump-prerelease-version@v0.1.1
+      
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: ${{ env.MESSAGE }}
+          body: Automatically created by ${{ env.RUN_LINK }}
+          commit-message: ${{ env.MESSAGE }}
+          branch: bot/bump-${{ steps.bump.outputs.new-version }}
+          base: main
+          author: GitHub <noreply@github.com>
+        env:
+          RUN_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MESSAGE: Bump version after release


### PR DESCRIPTION
Triggered when we publish a release on GitHub (can also manually trigger it). Creates a PR [like this one](https://github.com/alexweininger/bumper-test/pull/25) that bumps the prerelease version.

It uses [my own Action task](https://github.com/marketplace/actions/bump-prerelease-version) I published since I couldn't find one that already did what I needed. It has no dependencies.

If we like this, then I'll add it to all the other repos.