### PR TITLE
Allow creating .NET 7.0 Functions

### DIFF
--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -34,6 +34,6 @@ export async function createHttpFunction(context: IActionContext): Promise<void>
         templateId: 'HttpTrigger',
         languageFilter: /Python|C\#|^(Java|Type)Script$/i,
         functionSettings: { authLevel: 'anonymous' },
-        targetFramework: ['netcoreapp3.1', 'net6.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
+        targetFramework: ['netcoreapp3.1', 'net6.0', 'net7.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
     });
 }


### PR DESCRIPTION
This will allow users to create .NET 7.0 Functions. However, if they have .NET 6.0 and .NET 7.0 installed locally, then we will still default to .NET 6.0.

Fixes #758 