### PR TITLE
Remove support for creating .NET Core 3.1 functions

### DIFF
--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -34,6 +34,6 @@ export async function createHttpFunction(context: IActionContext): Promise<void>
         templateId: 'HttpTrigger',
         languageFilter: /Python|C\#|^(Java|Type)Script$/i,
         functionSettings: { authLevel: 'anonymous' },
-        targetFramework: ['netcoreapp3.1', 'net6.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
+        targetFramework: ['net6.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
     });
 }


### PR DESCRIPTION
See https://github.com/microsoft/vscode-azurestaticwebapps/issues/735#issuecomment-1276643673 for details. 

[.NET Core 3.1 support is ending December 3, 2022](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#selecting-the-api-language-runtime-version)