### PR TITLE
Remove spurious dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@azure/arm-appservice": "^11.0.0",
                 "@azure/arm-resources": "^5.0.0",
-                "@azure/ms-rest-js": "^2.2.1",
                 "@microsoft/vscode-azext-azureappservice": "^0.6.4",
                 "@microsoft/vscode-azext-azureutils": "^0.3.4",
                 "@microsoft/vscode-azext-utils": "^0.3.21",

--- a/package.json
+++ b/package.json
@@ -494,7 +494,6 @@
     "dependencies": {
         "@azure/arm-appservice": "^11.0.0",
         "@azure/arm-resources": "^5.0.0",
-        "@azure/ms-rest-js": "^2.2.1",
         "@microsoft/vscode-azext-azureappservice": "^0.6.4",
         "@microsoft/vscode-azext-azureutils": "^0.3.4",
         "@microsoft/vscode-azext-utils": "^0.3.21",


### PR DESCRIPTION
This doesn't really do much of anything right now--since it's still a nested dependency--but this dependency entry is not needed and removing it will be one (tiny) step toward vscode.dev support.