### PR TITLE
Use remote repositories API to enable create static web app in vscode.dev

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ let perfStats = {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const extension = require('./dist/extension.bundle');
+const extension = require('./out/src/extension');
 
 async function activate(ctx) {
     return await extension.activate(ctx, perfStats);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,11 @@
             "dependencies": {
                 "@azure/arm-appservice": "^11.0.0",
                 "@azure/arm-resources": "^5.0.0",
-                "@microsoft/vscode-azext-azureutils": "0.4.0-alpha",
+                "@microsoft/vscode-azext-azureutils": "0.4.0-alpha.1",
                 "@microsoft/vscode-azext-utils": "0.4.3-alpha",
                 "@microsoft/vscode-azureresources-api": "^2.0.3",
                 "@octokit/rest": "^18.5.2",
+                "buffer": "^6.0.3",
                 "dayjs": "^1.11.0",
                 "git-url-parse": "^13.1.0",
                 "open": "^8.0.4",
@@ -743,9 +744,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureutils": {
-            "version": "0.4.0-alpha",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-0.4.0-alpha.tgz",
-            "integrity": "sha512-8sDZR1t9ePYxkHeuh6JBWGxX4peR65ZoY8kiibrKiMOJqJ1pzyDM1KrLypNaYzoi4z6RY5CKqINuUJnQmyyGwA==",
+            "version": "0.4.0-alpha.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-0.4.0-alpha.1.tgz",
+            "integrity": "sha512-TMpVrao6dZ8/H0zeSKaKFsCEgq6SP2KC+5t7QaFyoWi0LW4WQEvBG2JVCBpVrGRM2hZa6ShiDBflM3L6kLaguQ==",
             "dependencies": {
                 "@azure/arm-resources": "^5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
@@ -757,6 +758,7 @@
                 "@microsoft/vscode-azext-utils": "0.4.3-alpha",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0",
+                "uuidv4": "^6.2.13",
                 "vscode-nls": "^5.0.1"
             }
         },
@@ -1854,6 +1856,11 @@
             "integrity": "sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==",
             "dev": true
         },
+        "node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+        },
         "node_modules/@types/vinyl": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.5.tgz",
@@ -2912,7 +2919,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2992,6 +2998,30 @@
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/bl/node_modules/readable-stream": {
@@ -3230,10 +3260,9 @@
             }
         },
         "node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
             "funding": [
                 {
                     "type": "github",
@@ -3250,7 +3279,7 @@
             ],
             "dependencies": {
                 "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
+                "ieee754": "^1.2.1"
             }
         },
         "node_modules/buffer-crc32": {
@@ -7382,7 +7411,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -12915,6 +12943,15 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "node_modules/uuidv4": {
+            "version": "6.2.13",
+            "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+            "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+            "dependencies": {
+                "@types/uuid": "8.3.4",
+                "uuid": "8.3.2"
+            }
+        },
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -14547,9 +14584,9 @@
             }
         },
         "@microsoft/vscode-azext-azureutils": {
-            "version": "0.4.0-alpha",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-0.4.0-alpha.tgz",
-            "integrity": "sha512-8sDZR1t9ePYxkHeuh6JBWGxX4peR65ZoY8kiibrKiMOJqJ1pzyDM1KrLypNaYzoi4z6RY5CKqINuUJnQmyyGwA==",
+            "version": "0.4.0-alpha.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-0.4.0-alpha.1.tgz",
+            "integrity": "sha512-TMpVrao6dZ8/H0zeSKaKFsCEgq6SP2KC+5t7QaFyoWi0LW4WQEvBG2JVCBpVrGRM2hZa6ShiDBflM3L6kLaguQ==",
             "requires": {
                 "@azure/arm-resources": "^5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
@@ -14561,6 +14598,7 @@
                 "@microsoft/vscode-azext-utils": "0.4.3-alpha",
                 "semver": "^7.3.7",
                 "uuid": "^9.0.0",
+                "uuidv4": "^6.2.13",
                 "vscode-nls": "^5.0.1"
             },
             "dependencies": {
@@ -15468,6 +15506,11 @@
             "integrity": "sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==",
             "dev": true
         },
+        "@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+        },
         "@types/vinyl": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.5.tgz",
@@ -16283,8 +16326,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "before-after-hook": {
             "version": "2.2.2",
@@ -16340,6 +16382,16 @@
                 "readable-stream": "^3.4.0"
             },
             "dependencies": {
+                "buffer": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+                    "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+                    "dev": true,
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.1.13"
+                    }
+                },
                 "readable-stream": {
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -16545,13 +16597,12 @@
             }
         },
         "buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
             "requires": {
                 "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
+                "ieee754": "^1.2.1"
             }
         },
         "buffer-crc32": {
@@ -19823,8 +19874,7 @@
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "ignore": {
             "version": "4.0.6",
@@ -24141,6 +24191,15 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "uuidv4": {
+            "version": "6.2.13",
+            "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+            "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+            "requires": {
+                "@types/uuid": "8.3.4",
+                "uuid": "8.3.2"
+            }
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -515,5 +515,7 @@
         "vscode-uri": "^3.0.2",
         "yaml": "^2.2.1"
     },
-    "extensionDependencies": []
+    "extensionDependencies": [
+        "ms-azuretools.vscode-azureresourcegroups"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
     ],
     "main": "./main.js",
     "browser": "./dist/web/extension.bundle.js",
+    "extensionKind": [
+        "ui",
+        "workspace"
+    ],
     "contributes": {
         "x-azResources": {
             "azure": {
@@ -114,7 +118,8 @@
             {
                 "command": "staticWebApps.appSettings.download",
                 "title": "%staticWebApps.appSettings.download%",
-                "category": "Azure Static Web Apps"
+                "category": "Azure Static Web Apps",
+                "enablement": "!isWeb"
             },
             {
                 "command": "staticWebApps.appSettings.edit",
@@ -129,7 +134,8 @@
             {
                 "command": "staticWebApps.appSettings.upload",
                 "title": "%staticWebApps.appSettings.upload%",
-                "category": "Azure Static Web Apps"
+                "category": "Azure Static Web Apps",
+                "enablement": "!isWeb"
             },
             {
                 "command": "staticWebApps.browse",
@@ -155,20 +161,17 @@
                 "command": "staticWebApps.createStaticWebApp",
                 "title": "%staticWebApps.createStaticWebApp%",
                 "category": "Azure Static Web Apps",
-                "icon": "$(add)",
-                "enablement": "!virtualWorkspace"
+                "icon": "$(add)"
             },
             {
                 "command": "staticWebApps.createStaticWebAppAdvanced",
                 "title": "%staticWebApps.createStaticWebAppAdvanced%",
-                "category": "Azure Static Web Apps",
-                "enablement": "!virtualWorkspace"
+                "category": "Azure Static Web Apps"
             },
             {
                 "command": "staticWebApps.createSwaConfigFile",
                 "title": "%staticWebApps.createSwaConfigFile%",
-                "category": "Azure Static Web Apps",
-                "enablement": "!virtualWorkspace"
+                "category": "Azure Static Web Apps"
             },
             {
                 "command": "staticWebApps.deleteEnvironment",
@@ -462,7 +465,9 @@
         "webpack": "npm run build && gulp webpack-dev",
         "webpack-prod": "npm run build && gulp webpack-prod",
         "webpack-profile": "webpack --profile --json --mode production > webpack-stats.json && echo Use http://webpack.github.io/analyse to analyze the stats",
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "serve": "npx serve --cors -l 5000",
+        "tunnel": "npx localtunnel -p 5000"
     },
     "devDependencies": {
         "@microsoft/eslint-config-azuretools": "^0.1.0",
@@ -497,10 +502,11 @@
     "dependencies": {
         "@azure/arm-appservice": "^11.0.0",
         "@azure/arm-resources": "^5.0.0",
-        "@microsoft/vscode-azext-azureutils": "0.4.0-alpha",
+        "@microsoft/vscode-azext-azureutils": "0.4.0-alpha.1",
         "@microsoft/vscode-azext-utils": "0.4.3-alpha",
         "@microsoft/vscode-azureresources-api": "^2.0.3",
         "@octokit/rest": "^18.5.2",
+        "buffer": "^6.0.3",
         "dayjs": "^1.11.0",
         "git-url-parse": "^13.1.0",
         "open": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,6 @@
     ],
     "main": "./main.js",
     "browser": "./dist/web/extension.bundle.js",
-    "extensionKind": [
-        "ui",
-        "workspace"
-    ],
     "contributes": {
         "x-azResources": {
             "azure": {
@@ -465,9 +461,7 @@
         "webpack": "npm run build && gulp webpack-dev",
         "webpack-prod": "npm run build && gulp webpack-prod",
         "webpack-profile": "webpack --profile --json --mode production > webpack-stats.json && echo Use http://webpack.github.io/analyse to analyze the stats",
-        "prepare": "husky install",
-        "serve": "npx serve --cors -l 5000",
-        "tunnel": "npx localtunnel -p 5000"
+        "prepare": "husky install"
     },
     "devDependencies": {
         "@microsoft/eslint-config-azuretools": "^0.1.0",

--- a/src/IGit.ts
+++ b/src/IGit.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, Event, Uri } from "vscode";
+import { APIState, PublishEvent, Repository } from "./git";
+import { Metadata, PostCommitCommandsProvider } from "./rrapi";
+
+
+
+export interface IGit {
+    readonly repositories: Repository[];
+    readonly onDidOpenRepository: Event<Repository>;
+    readonly onDidCloseRepository: Event<Repository>;
+    openRepository(root: Uri): Promise<Repository | null>
+
+    // Used by the actual git extension to indicate it has finished initializing state information
+    readonly state?: APIState;
+    readonly metadata?: Metadata;
+    readonly onDidChangeState?: Event<APIState>;
+    readonly onDidPublish?: Event<PublishEvent>;
+
+    registerPostCommitCommandsProvider?(provider: PostCommitCommandsProvider): Disposable;
+
+    // only applies for local git
+    init?(root: Uri): Promise<Repository | null>;
+}

--- a/src/IGit.ts
+++ b/src/IGit.ts
@@ -7,8 +7,6 @@ import { Disposable, Event, Uri } from "vscode";
 import { APIState, PublishEvent, Repository } from "./git";
 import { Metadata, PostCommitCommandsProvider } from "./rrapi";
 
-
-
 export interface IGit {
     readonly repositories: Repository[];
     readonly onDidOpenRepository: Event<Repository>;

--- a/src/RemoteRepoApi.ts
+++ b/src/RemoteRepoApi.ts
@@ -5,9 +5,10 @@
 
 import { AzureExtensionApi, createApiProvider } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
+import { AzureExtensionApiProvider } from '../azext-utils-api';
 import { revealTreeItem } from './commands/api/revealTreeItem';
-import { APIState, PublishEvent } from './git';
-import { API, IGit, PostCommitCommandsProvider, Repository } from './rrapi';
+import { APIState, IGit, PublishEvent } from './git';
+import { API, PostCommitCommandsProvider, Repository } from './rrapi';
 
 export const enum RefType {
     Head,
@@ -50,7 +51,7 @@ export const enum GitErrorCodes {
     PatchDoesNotApply = 'PatchDoesNotApply',
 }
 
-export class GitApiImpl implements API, IGit, vscode.Disposable {
+export class RemoteRepoApi implements AzureExtensionApiProvider, API, IGit, vscode.Disposable {
     private static _handlePool: number = 0;
     private _providers = new Map<number, IGit>();
 
@@ -64,6 +65,10 @@ export class GitApiImpl implements API, IGit, vscode.Disposable {
         });
 
         return ret;
+    }
+
+    public openRepository(uri: vscode.Uri): Repository | null {
+        return this.repositories.find(repo => uri === repo.rootUri) || null;
     }
 
     public get state(): APIState | undefined {
@@ -176,7 +181,7 @@ export class GitApiImpl implements API, IGit, vscode.Disposable {
     }
 
     private _nextHandle(): number {
-        return GitApiImpl._handlePool++;
+        return RemoteRepoApi._handlePool++;
     }
 
     dispose(): void {
@@ -184,9 +189,4 @@ export class GitApiImpl implements API, IGit, vscode.Disposable {
             disposable.dispose();
         }
     }
-
-    public openRepository(uri: vscode.Uri): Repository | null {
-        return this.repositories.find(repo => uri === repo.rootUri) || null;
-    }
-
 }

--- a/src/RemoteRepoApi.ts
+++ b/src/RemoteRepoApi.ts
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureExtensionApi, createApiProvider } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { revealTreeItem } from './commands/api/revealTreeItem';
+import { APIState, PublishEvent } from './git';
+import { API, IGit, PostCommitCommandsProvider, Repository } from './rrapi';
+
+export const enum RefType {
+    Head,
+    RemoteHead,
+    Tag,
+}
+
+export const enum GitErrorCodes {
+    BadConfigFile = 'BadConfigFile',
+    AuthenticationFailed = 'AuthenticationFailed',
+    NoUserNameConfigured = 'NoUserNameConfigured',
+    NoUserEmailConfigured = 'NoUserEmailConfigured',
+    NoRemoteRepositorySpecified = 'NoRemoteRepositorySpecified',
+    NotAGitRepository = 'NotAGitRepository',
+    NotAtRepositoryRoot = 'NotAtRepositoryRoot',
+    Conflict = 'Conflict',
+    StashConflict = 'StashConflict',
+    UnmergedChanges = 'UnmergedChanges',
+    PushRejected = 'PushRejected',
+    RemoteConnectionError = 'RemoteConnectionError',
+    DirtyWorkTree = 'DirtyWorkTree',
+    CantOpenResource = 'CantOpenResource',
+    GitNotFound = 'GitNotFound',
+    CantCreatePipe = 'CantCreatePipe',
+    CantAccessRemote = 'CantAccessRemote',
+    RepositoryNotFound = 'RepositoryNotFound',
+    RepositoryIsLocked = 'RepositoryIsLocked',
+    BranchNotFullyMerged = 'BranchNotFullyMerged',
+    NoRemoteReference = 'NoRemoteReference',
+    InvalidBranchName = 'InvalidBranchName',
+    BranchAlreadyExists = 'BranchAlreadyExists',
+    NoLocalChanges = 'NoLocalChanges',
+    NoStashFound = 'NoStashFound',
+    LocalChangesOverwritten = 'LocalChangesOverwritten',
+    NoUpstreamBranch = 'NoUpstreamBranch',
+    IsInSubmodule = 'IsInSubmodule',
+    WrongCase = 'WrongCase',
+    CantLockRef = 'CantLockRef',
+    CantRebaseMultipleBranches = 'CantRebaseMultipleBranches',
+    PatchDoesNotApply = 'PatchDoesNotApply',
+}
+
+export class GitApiImpl implements API, IGit, vscode.Disposable {
+    private static _handlePool: number = 0;
+    private _providers = new Map<number, IGit>();
+
+    public get repositories(): Repository[] {
+        const ret: Repository[] = [];
+
+        this._providers.forEach(({ repositories }) => {
+            if (repositories) {
+                ret.push(...repositories);
+            }
+        });
+
+        return ret;
+    }
+
+    public get state(): APIState | undefined {
+        if (this._providers.size === 0) {
+            return undefined;
+        }
+
+        for (const [, { state }] of this._providers) {
+            if (state !== 'initialized') {
+                return 'uninitialized';
+            }
+        }
+
+        return 'initialized';
+    }
+
+    public getApi = createApiProvider([<AzureExtensionApi>{
+        revealTreeItem,
+        apiVersion: '1.0.0'
+    }]).getApi;
+
+    private _onDidOpenRepository = new vscode.EventEmitter<Repository>();
+    readonly onDidOpenRepository: vscode.Event<Repository> = this._onDidOpenRepository.event;
+    private _onDidCloseRepository = new vscode.EventEmitter<Repository>();
+    readonly onDidCloseRepository: vscode.Event<Repository> = this._onDidCloseRepository.event;
+    private _onDidChangeState = new vscode.EventEmitter<APIState>();
+    readonly onDidChangeState: vscode.Event<APIState> = this._onDidChangeState.event;
+    private _onDidPublish = new vscode.EventEmitter<PublishEvent>();
+    readonly onDidPublish: vscode.Event<PublishEvent> = this._onDidPublish.event;
+
+    private _disposables: vscode.Disposable[];
+    constructor() {
+        this._disposables = [];
+    }
+
+    private _updateReposContext() {
+        const reposCount = Array.from(this._providers.values()).reduce((prev, current) => {
+            return prev + current.repositories.length;
+        }, 0);
+        void vscode.commands.executeCommand('setContext', 'gitHubOpenRepositoryCount', reposCount);
+    }
+
+    registerGitProvider(provider: IGit): vscode.Disposable {
+        const handle = this._nextHandle();
+        this._providers.set(handle, provider);
+
+        this._disposables.push(provider.onDidCloseRepository(e => this._onDidCloseRepository.fire(e)));
+        this._disposables.push(provider.onDidOpenRepository(e => {
+            this._updateReposContext();
+            this._onDidOpenRepository.fire(e);
+        }));
+        if (provider.onDidChangeState) {
+            console.log(provider.onDidChangeState);
+            this._disposables.push(provider.onDidChangeState(e => this._onDidChangeState.fire(e)));
+        }
+        if (provider.onDidPublish) {
+            this._disposables.push(provider.onDidPublish(e => this._onDidPublish.fire(e)));
+        }
+
+        this._updateReposContext();
+        provider.repositories.forEach(repository => {
+            this._onDidOpenRepository.fire(repository);
+        });
+
+        return {
+            dispose: () => {
+                const repos = provider?.repositories;
+                if (repos && repos.length > 0) {
+                    repos.forEach(r => this._onDidCloseRepository.fire(r));
+                }
+                this._providers.delete(handle);
+            },
+        };
+    }
+
+    getGitProvider(_uri: vscode.Uri): IGit | undefined {
+        const foldersMap = vscode.workspace.workspaceFolders;
+
+        this._providers.forEach(provider => {
+            const repos = provider.repositories;
+            if (repos && repos.length > 0) {
+                for (const repository of repos) {
+                    console.log(repository, foldersMap);
+                    // foldersMap.set(repository.rootUri, provider);
+                }
+            }
+        });
+
+        return undefined; //foldersMap.findSubstr(uri);
+    }
+
+    registerPostCommitCommandsProvider(provider: PostCommitCommandsProvider): vscode.Disposable {
+        const disposables = Array.from(this._providers.values()).map(gitProvider => {
+            if (gitProvider.registerPostCommitCommandsProvider) {
+                return gitProvider.registerPostCommitCommandsProvider(provider);
+            }
+            return {
+                dispose: (): void => {
+                    // do nothing
+                }
+            };
+        });
+        return {
+            dispose: () => {
+                for (const disposable of disposables) {
+                    disposable.dispose();
+                }
+            }
+        };
+    }
+
+    private _nextHandle(): number {
+        return GitApiImpl._handlePool++;
+    }
+
+    dispose(): void {
+        for (const disposable of this._disposables) {
+            disposable.dispose();
+        }
+    }
+
+    public openRepository(uri: vscode.Uri): Repository | null {
+        return this.repositories.find(repo => uri === repo.rootUri) || null;
+    }
+
+}

--- a/src/RemoteRepoApi.ts
+++ b/src/RemoteRepoApi.ts
@@ -6,9 +6,10 @@
 import { AzureExtensionApi, createApiProvider } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { AzureExtensionApiProvider } from '../azext-utils-api';
+import { IGit } from './IGit';
 import { revealTreeItem } from './commands/api/revealTreeItem';
-import { APIState, IGit, PublishEvent } from './git';
-import { API, PostCommitCommandsProvider, Repository } from './rrapi';
+import { APIState, PublishEvent } from './git';
+import { PostCommitCommandsProvider, RemoteRepository } from './rrapi';
 
 export const enum RefType {
     Head,
@@ -51,12 +52,12 @@ export const enum GitErrorCodes {
     PatchDoesNotApply = 'PatchDoesNotApply',
 }
 
-export class RemoteRepoApi implements AzureExtensionApiProvider, API, IGit, vscode.Disposable {
+export class RemoteRepoApi implements AzureExtensionApiProvider, IGit, vscode.Disposable {
     private static _handlePool: number = 0;
     private _providers = new Map<number, IGit>();
 
-    public get repositories(): Repository[] {
-        const ret: Repository[] = [];
+    public get repositories(): RemoteRepository[] {
+        const ret: RemoteRepository[] = [];
 
         this._providers.forEach(({ repositories }) => {
             if (repositories) {
@@ -67,7 +68,7 @@ export class RemoteRepoApi implements AzureExtensionApiProvider, API, IGit, vsco
         return ret;
     }
 
-    public openRepository(uri: vscode.Uri): Repository | null {
+    public async openRepository(uri: vscode.Uri): Promise<RemoteRepository | null> {
         return this.repositories.find(repo => uri === repo.rootUri) || null;
     }
 
@@ -90,10 +91,10 @@ export class RemoteRepoApi implements AzureExtensionApiProvider, API, IGit, vsco
         apiVersion: '1.0.0'
     }]).getApi;
 
-    private _onDidOpenRepository = new vscode.EventEmitter<Repository>();
-    readonly onDidOpenRepository: vscode.Event<Repository> = this._onDidOpenRepository.event;
-    private _onDidCloseRepository = new vscode.EventEmitter<Repository>();
-    readonly onDidCloseRepository: vscode.Event<Repository> = this._onDidCloseRepository.event;
+    private _onDidOpenRepository = new vscode.EventEmitter<RemoteRepository>();
+    readonly onDidOpenRepository: vscode.Event<RemoteRepository> = this._onDidOpenRepository.event;
+    private _onDidCloseRepository = new vscode.EventEmitter<RemoteRepository>();
+    readonly onDidCloseRepository: vscode.Event<RemoteRepository> = this._onDidCloseRepository.event;
     private _onDidChangeState = new vscode.EventEmitter<APIState>();
     readonly onDidChangeState: vscode.Event<APIState> = this._onDidChangeState.event;
     private _onDidPublish = new vscode.EventEmitter<PublishEvent>();

--- a/src/RemoteRepoApi.ts
+++ b/src/RemoteRepoApi.ts
@@ -86,6 +86,8 @@ export class RemoteRepoApi implements AzureExtensionApiProvider, IGit, vscode.Di
         return 'initialized';
     }
 
+    // Remote Repositories extension needs to have this API exported to be used,
+    // so we need to merge it with the Static Web App extension API. The easiest way to do this is to just implement getApi on RemoteRepoApi
     public getApi = createApiProvider([<AzureExtensionApi>{
         revealTreeItem,
         apiVersion: '1.0.0'
@@ -143,22 +145,6 @@ export class RemoteRepoApi implements AzureExtensionApiProvider, IGit, vscode.Di
                 this._providers.delete(handle);
             },
         };
-    }
-
-    getGitProvider(_uri: vscode.Uri): IGit | undefined {
-        const foldersMap = vscode.workspace.workspaceFolders;
-
-        this._providers.forEach(provider => {
-            const repos = provider.repositories;
-            if (repos && repos.length > 0) {
-                for (const repository of repos) {
-                    console.log(repository, foldersMap);
-                    // foldersMap.set(repository.rootUri, provider);
-                }
-            }
-        });
-
-        return undefined; //foldersMap.findSubstr(uri);
     }
 
     registerPostCommitCommandsProvider(provider: PostCommitCommandsProvider): vscode.Disposable {

--- a/src/RemoteRepoApi.ts
+++ b/src/RemoteRepoApi.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+
+// adopted from https://github.com/microsoft/vscode-pull-request-github/blob/main/src/api/api1.ts
 import { AzureExtensionApi, createApiProvider } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { AzureExtensionApiProvider } from '../azext-utils-api';
@@ -10,47 +12,6 @@ import { IGit } from './IGit';
 import { revealTreeItem } from './commands/api/revealTreeItem';
 import { APIState, PublishEvent } from './git';
 import { PostCommitCommandsProvider, RemoteRepository } from './rrapi';
-
-export const enum RefType {
-    Head,
-    RemoteHead,
-    Tag,
-}
-
-export const enum GitErrorCodes {
-    BadConfigFile = 'BadConfigFile',
-    AuthenticationFailed = 'AuthenticationFailed',
-    NoUserNameConfigured = 'NoUserNameConfigured',
-    NoUserEmailConfigured = 'NoUserEmailConfigured',
-    NoRemoteRepositorySpecified = 'NoRemoteRepositorySpecified',
-    NotAGitRepository = 'NotAGitRepository',
-    NotAtRepositoryRoot = 'NotAtRepositoryRoot',
-    Conflict = 'Conflict',
-    StashConflict = 'StashConflict',
-    UnmergedChanges = 'UnmergedChanges',
-    PushRejected = 'PushRejected',
-    RemoteConnectionError = 'RemoteConnectionError',
-    DirtyWorkTree = 'DirtyWorkTree',
-    CantOpenResource = 'CantOpenResource',
-    GitNotFound = 'GitNotFound',
-    CantCreatePipe = 'CantCreatePipe',
-    CantAccessRemote = 'CantAccessRemote',
-    RepositoryNotFound = 'RepositoryNotFound',
-    RepositoryIsLocked = 'RepositoryIsLocked',
-    BranchNotFullyMerged = 'BranchNotFullyMerged',
-    NoRemoteReference = 'NoRemoteReference',
-    InvalidBranchName = 'InvalidBranchName',
-    BranchAlreadyExists = 'BranchAlreadyExists',
-    NoLocalChanges = 'NoLocalChanges',
-    NoStashFound = 'NoStashFound',
-    LocalChangesOverwritten = 'LocalChangesOverwritten',
-    NoUpstreamBranch = 'NoUpstreamBranch',
-    IsInSubmodule = 'IsInSubmodule',
-    WrongCase = 'WrongCase',
-    CantLockRef = 'CantLockRef',
-    CantRebaseMultipleBranches = 'CantRebaseMultipleBranches',
-    PatchDoesNotApply = 'PatchDoesNotApply',
-}
 
 export class RemoteRepoApi implements AzureExtensionApiProvider, IGit, vscode.Disposable {
     private static _handlePool: number = 0;

--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -24,7 +24,7 @@ export async function createHttpFunction(context: IActionContext): Promise<void>
 
     const apiLocation: string = detectedApiLocations?.length ?
         await promptForApiFolder(context, detectedApiLocations) :
-        getWorkspaceSetting(apiSubpathSetting, workspace.workspaceFolders[0].uri.fsPath) || defaultApiLocation;
+        getWorkspaceSetting(apiSubpathSetting, workspace.workspaceFolders[0].uri) || defaultApiLocation;
     const folderPath: string = path.join(workspace.workspaceFolders[0].uri.fsPath, apiLocation);
 
     const funcApi: AzureFunctionsExtensionApi = await getFunctionsApi(context);

--- a/src/commands/createRepo/RemoteShortnameStep.ts
+++ b/src/commands/createRepo/RemoteShortnameStep.ts
@@ -5,6 +5,7 @@
 
 import { AzureWizardPromptStep, nonNullProp, parseError } from '@microsoft/vscode-azext-utils';
 import { basename } from 'path';
+import { Uri } from 'vscode';
 import { cpUtils } from '../../utils/cpUtils';
 import { remoteShortnameExists } from '../../utils/gitUtils';
 import { localize } from '../../utils/localize';
@@ -25,7 +26,7 @@ export class RemoteShortnameStep extends AzureWizardPromptStep<IStaticWebAppWiza
                     // remotes have same naming rules as branches
                     // https://stackoverflow.com/questions/41461152/which-characters-are-illegal-within-a-git-remote-name
                     try {
-                        await cpUtils.executeCommand(undefined, context.fsPath, 'git', 'check-ref-format', '--branch', cpUtils.wrapArgInQuotes(value));
+                        await cpUtils.executeCommand(undefined, context.uri?.fsPath, 'git', 'check-ref-format', '--branch', cpUtils.wrapArgInQuotes(value));
                     } catch (err) {
                         if (/is not a valid branch name/g.test(parseError(err).message)) {
                             return localize('notValid', '"{0}" is not a valid remote shortname.', value);
@@ -33,9 +34,9 @@ export class RemoteShortnameStep extends AzureWizardPromptStep<IStaticWebAppWiza
                         // ignore other errors, we may not be able to access git so we shouldn't block users here
                     }
 
-                    const fsPath: string = nonNullProp(context, 'fsPath');
+                    const fsPath: Uri = nonNullProp(context, 'uri');
                     if (await remoteShortnameExists(fsPath, value)) {
-                        return localize('remoteExists', 'Remote shortname "{0}" already exists in "{1}".', value, basename(fsPath));
+                        return localize('remoteExists', 'Remote shortname "{0}" already exists in "{1}".', value, basename(fsPath.fsPath));
                     }
                 }
 

--- a/src/commands/createRepo/RemoteShortnameStep.ts
+++ b/src/commands/createRepo/RemoteShortnameStep.ts
@@ -32,11 +32,12 @@ export class RemoteShortnameStep extends AzureWizardPromptStep<IStaticWebAppWiza
                             return localize('notValid', '"{0}" is not a valid remote shortname.', value);
                         }
                         // ignore other errors, we may not be able to access git so we shouldn't block users here
+                        // this also will not work for vscode.dev
                     }
 
-                    const fsPath: Uri = nonNullProp(context, 'uri');
-                    if (await remoteShortnameExists(fsPath, value)) {
-                        return localize('remoteExists', 'Remote shortname "{0}" already exists in "{1}".', value, basename(fsPath.fsPath));
+                    const uri: Uri = nonNullProp(context, 'uri');
+                    if (await remoteShortnameExists(uri, value)) {
+                        return localize('remoteExists', 'Remote shortname "{0}" already exists in "{1}".', value, basename(uri.fsPath));
                     }
                 }
 

--- a/src/commands/createStaticWebApp/ApiLocationStep.ts
+++ b/src/commands/createStaticWebApp/ApiLocationStep.ts
@@ -8,14 +8,14 @@ import { apiSubpathSetting, defaultApiLocation } from "../../constants";
 import { localize } from "../../utils/localize";
 import { getWorkspaceSetting } from "../../utils/settingsUtils";
 import { validateLocationYaml } from "../../utils/yamlUtils";
-import { addLocationTelemetry } from "./addLocationTelemetry";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
+import { addLocationTelemetry } from "./addLocationTelemetry";
 import { promptForApiFolder } from "./tryGetApiLocations";
 
 export class ApiLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const defaultValue: string = context.buildPreset?.apiLocation ?? defaultApiLocation;
-        const workspaceSetting: string | undefined = getWorkspaceSetting(apiSubpathSetting, context.fsPath);
+        const workspaceSetting: string | undefined = getWorkspaceSetting(apiSubpathSetting, context.uri?.fsPath);
 
         context.apiLocation = context.detectedApiLocations?.length ?
             await promptForApiFolder(context, context.detectedApiLocations) :

--- a/src/commands/createStaticWebApp/ApiLocationStep.ts
+++ b/src/commands/createStaticWebApp/ApiLocationStep.ts
@@ -15,7 +15,7 @@ import { promptForApiFolder } from "./tryGetApiLocations";
 export class ApiLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const defaultValue: string = context.buildPreset?.apiLocation ?? defaultApiLocation;
-        const workspaceSetting: string | undefined = getWorkspaceSetting(apiSubpathSetting, context.uri?.fsPath);
+        const workspaceSetting: string | undefined = getWorkspaceSetting(apiSubpathSetting, context.uri);
 
         context.apiLocation = context.detectedApiLocations?.length ?
             await promptForApiFolder(context, context.detectedApiLocations) :

--- a/src/commands/createStaticWebApp/AppLocationStep.ts
+++ b/src/commands/createStaticWebApp/AppLocationStep.ts
@@ -8,13 +8,13 @@ import { appSubpathSetting, defaultAppLocation } from "../../constants";
 import { localize } from "../../utils/localize";
 import { getWorkspaceSetting } from "../../utils/settingsUtils";
 import { validateLocationYaml } from "../../utils/yamlUtils";
-import { addLocationTelemetry } from "./addLocationTelemetry";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
+import { addLocationTelemetry } from "./addLocationTelemetry";
 
 export class AppLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const defaultValue: string = context.buildPreset?.appLocation ?? defaultAppLocation;
-        const workspaceSetting: string | undefined = getWorkspaceSetting(appSubpathSetting, context.fsPath);
+        const workspaceSetting: string | undefined = getWorkspaceSetting(appSubpathSetting, context.uri?.fsPath);
 
         context.appLocation = (await context.ui.showInputBox({
             value: workspaceSetting || defaultValue,

--- a/src/commands/createStaticWebApp/AppLocationStep.ts
+++ b/src/commands/createStaticWebApp/AppLocationStep.ts
@@ -14,7 +14,7 @@ import { addLocationTelemetry } from "./addLocationTelemetry";
 export class AppLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const defaultValue: string = context.buildPreset?.appLocation ?? defaultAppLocation;
-        const workspaceSetting: string | undefined = getWorkspaceSetting(appSubpathSetting, context.uri?.fsPath);
+        const workspaceSetting: string | undefined = getWorkspaceSetting(appSubpathSetting, context.uri);
 
         context.appLocation = (await context.ui.showInputBox({
             value: workspaceSetting || defaultValue,

--- a/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
+++ b/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
@@ -6,6 +6,7 @@
 import { SkuDescription, StaticSiteARMResource, WebSiteManagementClient } from '@azure/arm-appservice';
 import { IResourceGroupWizardContext } from '@microsoft/vscode-azext-azureutils';
 import { ExecuteActivityContext } from '@microsoft/vscode-azext-utils';
+import { Uri } from 'vscode';
 import { IBuildPreset } from '../../buildPresets/IBuildPreset';
 import { Repository } from '../../git';
 import { BranchData, ListOrgsForUserData, OrgForAuthenticatedUserData } from '../../gitHubTypings';
@@ -20,7 +21,7 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext,
     repoHtmlUrl?: string;
 
     repo?: Repository;
-    fsPath?: string;
+    uri?: Uri;
 
     // Function projects detected via host.json at SWA create time
     detectedApiLocations?: string[];

--- a/src/commands/createStaticWebApp/OutputLocationStep.ts
+++ b/src/commands/createStaticWebApp/OutputLocationStep.ts
@@ -8,16 +8,16 @@ import { angularOutputLocation, appArtifactSubpathSetting, outputSubpathSetting 
 import { localize } from "../../utils/localize";
 import { getWorkspaceSetting } from "../../utils/settingsUtils";
 import { validateLocationYaml } from "../../utils/yamlUtils";
-import { addLocationTelemetry } from "./addLocationTelemetry";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
+import { addLocationTelemetry } from "./addLocationTelemetry";
 
 export class OutputLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const defaultValue: string = context.buildPreset?.outputLocation ?? 'build';
-        const workspaceSetting: string | undefined = getWorkspaceSetting(outputSubpathSetting, context.fsPath);
+        const workspaceSetting: string | undefined = getWorkspaceSetting(outputSubpathSetting, context.uri?.fsPath);
 
         context.outputLocation = (await context.ui.showInputBox({
-            value: workspaceSetting || getWorkspaceSetting(appArtifactSubpathSetting, context.fsPath) || defaultValue,
+            value: workspaceSetting || getWorkspaceSetting(appArtifactSubpathSetting, context.uri?.fsPath) || defaultValue,
             prompt: localize('publishLocation', "Enter the location of your build output relative to your app's location or leave blank if it has no build. For example, setting a value of 'build' when your app location is set to 'app' will cause the content at 'app/build' to be served."),
             learnMoreLink: 'https://aka.ms/SwaOutLoc',
             validateInput: (value: string): string | undefined => {

--- a/src/commands/createStaticWebApp/OutputLocationStep.ts
+++ b/src/commands/createStaticWebApp/OutputLocationStep.ts
@@ -14,10 +14,10 @@ import { addLocationTelemetry } from "./addLocationTelemetry";
 export class OutputLocationStep extends AzureWizardPromptStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
         const defaultValue: string = context.buildPreset?.outputLocation ?? 'build';
-        const workspaceSetting: string | undefined = getWorkspaceSetting(outputSubpathSetting, context.uri?.fsPath);
+        const workspaceSetting: string | undefined = getWorkspaceSetting(outputSubpathSetting, context.uri);
 
         context.outputLocation = (await context.ui.showInputBox({
-            value: workspaceSetting || getWorkspaceSetting(appArtifactSubpathSetting, context.uri?.fsPath) || defaultValue,
+            value: workspaceSetting || getWorkspaceSetting(appArtifactSubpathSetting, context.uri) || defaultValue,
             prompt: localize('publishLocation', "Enter the location of your build output relative to your app's location or leave blank if it has no build. For example, setting a value of 'build' when your app location is set to 'app' will cause the content at 'app/build' to be served."),
             learnMoreLink: 'https://aka.ms/SwaOutLoc',
             validateInput: (value: string): string | undefined => {

--- a/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppNameStep.ts
@@ -18,7 +18,7 @@ export const staticWebAppNamingRules: IAzureNamingRules = {
 
 export class StaticWebAppNameStep extends AzureNameStep<IStaticWebAppWizardContext> {
     public async prompt(context: IStaticWebAppWizardContext): Promise<void> {
-        const folderName: string = path.basename(nonNullProp(context, 'fsPath'));
+        const folderName: string = path.basename(nonNullProp(context, 'uri').fsPath);
 
         const prompt: string = localize('staticWebAppNamePrompt', 'Enter a name for the new static web app.');
         context.newStaticWebAppName = (await context.ui.showInputBox({

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -9,11 +9,11 @@ import { AzExtFsExtra, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptSte
 import { AppResource } from '@microsoft/vscode-azext-utils/hostapi';
 import { ProgressLocation, ProgressOptions, Uri, window, workspace } from 'vscode';
 import { Utils } from 'vscode-uri';
-import { NodeConstants } from '../../detectors/node/nodeConstants';
+import { StaticWebAppResolver } from '../../StaticWebAppResolver';
 import { DetectorResults, NodeDetector } from '../../detectors/node/NodeDetector';
+import { NodeConstants } from '../../detectors/node/nodeConstants';
 import { VerifyingWorkspaceError } from '../../errors';
 import { ext } from '../../extensionVariables';
-import { StaticWebAppResolver } from '../../StaticWebAppResolver';
 import { createActivityContext } from '../../utils/activityUtils';
 import { createWebSiteClient } from '../../utils/azureClients';
 import { getGitHubAccessToken } from '../../utils/gitHubUtils';
@@ -32,10 +32,10 @@ import { BuildPresetListStep } from './BuildPresetListStep';
 import { GitHubOrgListStep } from './GitHubOrgListStep';
 import { IStaticWebAppWizardContext } from './IStaticWebAppWizardContext';
 import { OutputLocationStep } from './OutputLocationStep';
-import { setWorkspaceContexts } from './setWorkspaceContexts';
 import { SkuListStep } from './SkuListStep';
 import { StaticWebAppCreateStep } from './StaticWebAppCreateStep';
 import { StaticWebAppNameStep } from './StaticWebAppNameStep';
+import { setWorkspaceContexts } from './setWorkspaceContexts';
 import { tryGetApiLocations } from './tryGetApiLocations';
 
 let isVerifyingWorkspace: boolean = false;
@@ -86,6 +86,7 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
                     }
                 });
 
+                // this is the entry point for using git stuff. I think we should refactor this to be more obvious that git is being used here
                 await setWorkspaceContexts(context, folder);
                 context.detectedApiLocations = await tryGetApiLocations(context, folder);
             } else {

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -156,7 +156,7 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
     });
 
     wizardContext.telemetry.properties.gotRemote = String(hasRemote);
-    wizardContext.fsPath = wizardContext.fsPath || getSingleRootFsPath();
+    wizardContext.uri = wizardContext.uri || getSingleRootFsPath();
     wizardContext.telemetry.properties.numberOfWorkspaces = !workspace.workspaceFolders ? String(0) : String(workspace.workspaceFolders.length);
 
     await wizard.prompt();

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -35,7 +35,7 @@ import { OutputLocationStep } from './OutputLocationStep';
 import { SkuListStep } from './SkuListStep';
 import { StaticWebAppCreateStep } from './StaticWebAppCreateStep';
 import { StaticWebAppNameStep } from './StaticWebAppNameStep';
-import { setWorkspaceContexts } from './setWorkspaceContexts';
+import { setGitWorkspaceContexts } from './setWorkspaceContexts';
 import { tryGetApiLocations } from './tryGetApiLocations';
 
 let isVerifyingWorkspace: boolean = false;
@@ -86,8 +86,7 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
                     }
                 });
 
-                // this is the entry point for using git stuff. I think we should refactor this to be more obvious that git is being used here
-                await setWorkspaceContexts(context, folder);
+                await setGitWorkspaceContexts(context, folder);
                 context.detectedApiLocations = await tryGetApiLocations(context, folder);
             } else {
                 await showNoWorkspacePrompt(context);

--- a/src/commands/createStaticWebApp/setWorkspaceContexts.ts
+++ b/src/commands/createStaticWebApp/setWorkspaceContexts.ts
@@ -15,7 +15,7 @@ export async function setWorkspaceContexts(context: IActionContext & Partial<ISt
     const verifiedWorkspace: VerifiedGitWorkspaceState = await verifyGitWorkspaceForCreation(context, gitWorkspaceState, folder.uri);
 
     await warnIfNotOnDefaultBranch(context, verifiedWorkspace);
-    context.fsPath = folder.uri.fsPath;
+    context.uri = folder.uri;
     context.repo = verifiedWorkspace.repo;
 
     if (gitWorkspaceState.remoteRepo) {

--- a/src/commands/createStaticWebApp/setWorkspaceContexts.ts
+++ b/src/commands/createStaticWebApp/setWorkspaceContexts.ts
@@ -36,7 +36,8 @@ export async function setWorkspaceContexts(context: IActionContext & Partial<ISt
             context.orgData = await GitHubOrgListStep.getAuthenticatedUser(context);
         }
     }
+
     const origin: string = 'origin';
-    context.originExists = await remoteShortnameExists(context.fsPath, origin);
+    context.originExists = await remoteShortnameExists(folder.uri, origin);
     context.newRemoteShortname = context.originExists ? undefined : origin;
 }

--- a/src/commands/createStaticWebApp/setWorkspaceContexts.ts
+++ b/src/commands/createStaticWebApp/setWorkspaceContexts.ts
@@ -10,7 +10,7 @@ import { localize } from '../../utils/localize';
 import { GitHubOrgListStep } from './GitHubOrgListStep';
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
-export async function setWorkspaceContexts(context: IActionContext & Partial<IStaticWebAppWizardContext>, folder: WorkspaceFolder): Promise<void> {
+export async function setGitWorkspaceContexts(context: IActionContext & Partial<IStaticWebAppWizardContext>, folder: WorkspaceFolder): Promise<void> {
     const gitWorkspaceState: GitWorkspaceState = await getGitWorkspaceState(context, folder.uri);
     const verifiedWorkspace: VerifiedGitWorkspaceState = await verifyGitWorkspaceForCreation(context, gitWorkspaceState, folder.uri);
 

--- a/src/commands/createStaticWebApp/tryGetApiLocations.ts
+++ b/src/commands/createStaticWebApp/tryGetApiLocations.ts
@@ -5,7 +5,8 @@
 
 import { AzExtFsExtra, IActionContext } from "@microsoft/vscode-azext-utils";
 import * as path from 'path';
-import { RelativePattern, workspace, WorkspaceFolder } from "vscode";
+import { RelativePattern, WorkspaceFolder, workspace } from "vscode";
+import { URI, Utils } from "vscode-uri";
 import { localize } from '../../utils/localize';
 import { telemetryUtils } from '../../utils/telemetryUtils';
 
@@ -55,5 +56,5 @@ export async function promptForApiFolder(context: IActionContext, detectedApiLoc
 
 // Use 'host.json' as an indicator that this is a functions project
 async function isFunctionProject(folderPath: string): Promise<boolean> {
-    return await AzExtFsExtra.pathExists(path.join(folderPath, hostFileName));
+    return await AzExtFsExtra.pathExists(Utils.joinPath(URI.parse(folderPath), hostFileName));
 }

--- a/src/commands/createSwaConfigFile.ts
+++ b/src/commands/createSwaConfigFile.ts
@@ -4,24 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtFsExtra, IActionContext } from '@microsoft/vscode-azext-utils';
-import { join } from 'path';
-import { MessageItem, Uri, window } from 'vscode';
+import { MessageItem, window } from 'vscode';
+import { URI, Utils } from 'vscode-uri';
 import { configFileName } from '../constants';
 import { localize } from '../utils/localize';
 import { selectWorkspaceFolder } from '../utils/workspaceUtils';
 
 export async function createSwaConfigFile(context: IActionContext): Promise<void> {
     const destPath: string = await selectWorkspaceFolder(context, localize('selectConfigFileLocation', 'Select location to create "{0}"', configFileName));
-    const configFilePath: string = join(destPath, configFileName);
+    const configFilePath: URI = Utils.joinPath(URI.parse(destPath), configFileName);
 
     if (await AzExtFsExtra.pathExists(configFilePath)) {
-        const configFileExists: string = localize('configFileExists', 'Static Web App configuration file "{0}" already exists.', configFilePath);
+        const configFileExists: string = localize('configFileExists', 'Static Web App configuration file "{0}" already exists.', configFilePath.fsPath);
         const overwrite: MessageItem = { title: localize('overwrite', 'Overwrite') };
         await context.ui.showWarningMessage(configFileExists, { modal: true }, overwrite);
     }
 
     await AzExtFsExtra.writeFile(configFilePath, exampleConfigFile);
-    await window.showTextDocument(Uri.file(configFilePath));
+    await window.showTextDocument(configFilePath);
 }
 
 // Source: https://json.schemastore.org/staticwebapp.config.json

--- a/src/commands/github/showActions.ts
+++ b/src/commands/github/showActions.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
+import { ResolvedStaticWebApp } from '../../StaticWebAppResolver';
 import { swaFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
-import { ResolvedStaticWebApp } from '../../StaticWebAppResolver';
 import { ActionsTreeItem } from '../../tree/ActionsTreeItem';
 import { openUrl } from '../../utils/openUrl';
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,7 @@ export const isStartGroup = (t: string): boolean => /##\[group\]/.test(t);
 export const isEndGroup = (t: string): boolean => /##\[endgroup\]/.test(t)
 
 export const githubAuthProviderId: string = 'github';
-export const githubScopes: string[] = ['repo', 'workflow', 'admin:public_key'];
+export const githubScopes: string[] = ['repo', 'workflow', 'user:email', 'read:user'];
 
 export const angularOutputLocation = 'dist/<project-name>';
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export const isStartGroup = (t: string): boolean => /##\[group\]/.test(t);
 export const isEndGroup = (t: string): boolean => /##\[endgroup\]/.test(t)
 
 export const githubAuthProviderId: string = 'github';
+// same scopes as the GitHub extension so we won't have to prompt for auth again
 export const githubScopes: string[] = ['repo', 'workflow', 'user:email', 'read:user'];
 
 export const angularOutputLocation = 'dist/<project-name>';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import { githubAuthProviderId, githubScopes, pwaChrome, shell, swa } from './con
 import { StaticWebAppDebugProvider } from './debug/StaticWebAppDebugProvider';
 import { ext } from './extensionVariables';
 import { getResourceGroupsApi } from './getExtensionApi';
-import { GitApiImpl } from './RemoteRepoApi';
+import { RemoteRepoApi } from './RemoteRepoApi';
 import { StaticWebAppResolver } from './StaticWebAppResolver';
 
 export async function activate(context: vscode.ExtensionContext, _perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<apiUtils.AzureExtensionApiProvider> {
@@ -51,15 +51,15 @@ export async function activate(context: vscode.ExtensionContext, _perfStats: { l
         ext.rgApi = await getResourceGroupsApi();
         ext.rgApi.registerApplicationResourceResolver(AzExtResourceType.StaticWebApps, new StaticWebAppResolver());
 
-        ext.gitApi = new GitApiImpl();
+        ext.remoteRepoApi = new RemoteRepoApi();
         registerSwaCliTaskEvents();
-
         registerCommands();
 
         // ext.experimentationService = await createExperimentationService(context);
     });
 
-    return ext.gitApi;
+    // remoteRepoApi is combined with the SWA API required for resource gropus, but the remote repo relies on extension exports
+    return ext.remoteRepoApi;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,11 +6,10 @@
 'use strict';
 
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
-import { callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, IActionContext, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
-import { apiUtils, AzExtResourceType, AzureExtensionApi } from "@microsoft/vscode-azureresources-api";
+import { callWithTelemetryAndErrorHandling, createAzExtOutputChannel, IActionContext, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import { apiUtils, AzExtResourceType } from "@microsoft/vscode-azureresources-api";
 import * as vscode from 'vscode';
 import { SwaTaskProvider } from './cli/SwaCliTaskProvider';
-import { revealTreeItem } from './commands/api/revealTreeItem';
 import { registerSwaCliTaskEvents } from './commands/cli/swaCliTask';
 import { validateStaticWebAppsCliIsLatest } from './commands/cli/validateSwaCliIsLatest';
 import { contentScheme } from './commands/github/jobLogs/GitHubLogContentProvider';
@@ -20,6 +19,7 @@ import { githubAuthProviderId, githubScopes, pwaChrome, shell, swa } from './con
 import { StaticWebAppDebugProvider } from './debug/StaticWebAppDebugProvider';
 import { ext } from './extensionVariables';
 import { getResourceGroupsApi } from './getExtensionApi';
+import { GitApiImpl } from './RemoteRepoApi';
 import { StaticWebAppResolver } from './StaticWebAppResolver';
 
 export async function activate(context: vscode.ExtensionContext, _perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<apiUtils.AzureExtensionApiProvider> {
@@ -51,6 +51,7 @@ export async function activate(context: vscode.ExtensionContext, _perfStats: { l
         ext.rgApi = await getResourceGroupsApi();
         ext.rgApi.registerApplicationResourceResolver(AzExtResourceType.StaticWebApps, new StaticWebAppResolver());
 
+        ext.gitApi = new GitApiImpl();
         registerSwaCliTaskEvents();
 
         registerCommands();
@@ -58,10 +59,7 @@ export async function activate(context: vscode.ExtensionContext, _perfStats: { l
         // ext.experimentationService = await createExperimentationService(context);
     });
 
-    return createApiProvider([<AzureExtensionApi>{
-        revealTreeItem,
-        apiVersion: '1.0.0'
-    }]);
+    return ext.gitApi;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,11 @@ import { getResourceGroupsApi } from './getExtensionApi';
 import { RemoteRepoApi } from './RemoteRepoApi';
 import { StaticWebAppResolver } from './StaticWebAppResolver';
 
-export async function activate(context: vscode.ExtensionContext, _perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<apiUtils.AzureExtensionApiProvider> {
+export async function activate(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<apiUtils.AzureExtensionApiProvider> {
+    // the entry point for vscode.dev is this activate, not main.js, so we need to instantiate perfStats here
+    // the perf stats don't matter for vscode because there is no main file to load-- we may need to see if we can track the download time
+    perfStats ||= { loadStartTime: Date.now(), loadEndTime: Date.now() };
+
     ext.context = context;
     ext.ignoreBundle = ignoreBundle;
     ext.outputChannel = createAzExtOutputChannel('Azure Static Web Apps', ext.prefix);
@@ -33,7 +37,7 @@ export async function activate(context: vscode.ExtensionContext, _perfStats: { l
 
     await callWithTelemetryAndErrorHandling('staticWebApps.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
-        // activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
+        activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
         void validateStaticWebAppsCliIsLatest();
 
         /**

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -7,7 +7,7 @@ import { IAzExtOutputChannel, IExperimentationServiceAdapter } from "@microsoft/
 import { AzureHostExtensionApi } from "@microsoft/vscode-azext-utils/hostapi";
 import { ExtensionContext } from "vscode";
 import { RemoteRepoApi } from "./RemoteRepoApi";
-import { API } from "./git";
+import { GitAPI } from "./git";
 
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
@@ -20,5 +20,5 @@ export namespace ext {
     export let experimentationService: IExperimentationServiceAdapter;
     export let rgApi: AzureHostExtensionApi;
     export let remoteRepoApi: RemoteRepoApi;
-    export let vscodeGitApi: API;
+    export let vscodeGitApi: GitAPI;
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -6,6 +6,7 @@
 import { IAzExtOutputChannel, IExperimentationServiceAdapter } from "@microsoft/vscode-azext-utils";
 import { AzureHostExtensionApi } from "@microsoft/vscode-azext-utils/hostapi";
 import { ExtensionContext } from "vscode";
+import { API } from "./rrapi";
 
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
@@ -17,4 +18,5 @@ export namespace ext {
     export const prefix: string = 'staticWebApps';
     export let experimentationService: IExperimentationServiceAdapter;
     export let rgApi: AzureHostExtensionApi;
+    export let gitApi: API;
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -6,7 +6,8 @@
 import { IAzExtOutputChannel, IExperimentationServiceAdapter } from "@microsoft/vscode-azext-utils";
 import { AzureHostExtensionApi } from "@microsoft/vscode-azext-utils/hostapi";
 import { ExtensionContext } from "vscode";
-import { API } from "./rrapi";
+import { RemoteRepoApi } from "./RemoteRepoApi";
+import { API } from "./git";
 
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
@@ -18,5 +19,6 @@ export namespace ext {
     export const prefix: string = 'staticWebApps';
     export let experimentationService: IExperimentationServiceAdapter;
     export let rgApi: AzureHostExtensionApi;
-    export let gitApi: API;
+    export let remoteRepoApi: RemoteRepoApi;
+    export let vscodeGitApi: API;
 }

--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -8,8 +8,9 @@ import { AzureHostExtensionApi } from "@microsoft/vscode-azext-utils/hostapi";
 import { apiUtils } from '@microsoft/vscode-azureresources-api';
 import { Extension, commands, extensions } from "vscode";
 import { AzureExtensionApiProvider } from "../azext-utils-api";
+import { IGit } from "./IGit";
 import { ext } from "./extensionVariables";
-import { API, GitExtension, IGit } from "./git";
+import { GitExtension } from "./git";
 import { localize } from "./utils/localize";
 import { getWorkspaceSetting } from "./utils/settingsUtils";
 import { AzureFunctionsExtensionApi } from "./vscode-azurefunctions.api";
@@ -35,23 +36,8 @@ export async function getFunctionsApi(context: IActionContext, installMessage?: 
 }
 
 export async function getGitApi(): Promise<IGit> {
-    // this is where we would have a split in logic
-    // check if there is a remote repo opened (this can be in web or desktop)
-    // if not, then we can check if there is a local repo opened
-    // if we have access to git, we should use this method
-
-    // how to refactor?
-    // we could either have two totally separate methods or select the logic based on the context
-    // having separate methods might be a little cleaner, but it would be a lot of duplicated code
-
-    // I think Git API and Remote Hubs should have the same API so just determined which to use
-    // Things to check:
-    // Can I have a remote opened with a local repo?
-    // Should I switch everything to API calls instead of using local git?
-    // What happens if I have multiple repos open?
-
     try {
-        // if we have a remote repo, we should use that
+        // if there is no remote repo state, then try to get the local git api
         if (!ext.remoteRepoApi.state) {
             if (!ext.vscodeGitApi) {
                 const gitExtension: GitExtension | undefined = await apiUtils.getExtensionExports('vscode.git');
@@ -65,7 +51,7 @@ export async function getGitApi(): Promise<IGit> {
                 throw new Error(localize('unableGit', 'Unable to retrieve VS Code Git API. Please ensure git is properly installed and reload VS Code.'));
             }
         } else {
-            return ext.remoteRepoApi as unknown as API;
+            return ext.remoteRepoApi;
         }
     } catch (err) {
         if (!getWorkspaceSetting<boolean>('enabled', undefined, 'git')) {

--- a/src/git.d.ts
+++ b/src/git.d.ts
@@ -5,6 +5,7 @@
 
 // copied from https://github.com/microsoft/vscode/blob/master/extensions/git/src/api/git.d.ts
 import { Disposable, Event, ProviderResult, Uri } from 'vscode';
+import { PostCommitCommandsProvider } from './rrapi';
 export { ProviderResult } from 'vscode';
 
 export interface Git {
@@ -325,4 +326,31 @@ export const enum GitErrorCodes {
     PatchDoesNotApply = 'PatchDoesNotApply',
     NoPathFound = 'NoPathFound',
     UnknownPath = 'UnknownPath',
+}
+
+export interface RemoteSourcePublisher {
+    readonly name: string;
+    readonly icon?: string; // codicon name
+    publishRepository(repository: Repository): Promise<void>;
+}
+
+export interface GitAPI {
+    readonly state: APIState;
+    readonly onDidChangeState: Event<APIState>;
+    readonly onDidPublish: Event<PublishEvent>;
+    readonly git: Git;
+    readonly repositories: Repository[];
+    readonly onDidOpenRepository: Event<Repository>;
+    readonly onDidCloseRepository: Event<Repository>;
+
+    toGitUri(uri: Uri, ref: string): Uri;
+    getRepository(uri: Uri): Repository | null;
+    init(root: Uri): Promise<Repository | null>;
+    openRepository(root: Uri): Promise<Repository | null>
+
+    registerRemoteSourcePublisher(publisher: RemoteSourcePublisher): Disposable;
+    registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable;
+    registerCredentialsProvider(provider: CredentialsProvider): Disposable;
+    registerPostCommitCommandsProvider(provider: PostCommitCommandsProvider): Disposable;
+    registerPushErrorHandler(handler: PushErrorHandler): Disposable;
 }

--- a/src/git.d.ts
+++ b/src/git.d.ts
@@ -5,7 +5,7 @@
 
 // copied from https://github.com/microsoft/vscode/blob/master/extensions/git/src/api/git.d.ts
 import { Disposable, Event, ProviderResult, Uri } from 'vscode';
-import { PostCommitCommandsProvider } from './rrapi';
+import { Metadata, PostCommitCommandsProvider, Repository as RemoteRepository } from './rrapi';
 export { ProviderResult } from 'vscode';
 
 export interface Git {
@@ -253,7 +253,7 @@ export interface PublishEvent {
     branch?: string;
 }
 
-export interface API {
+export interface API extends IGit {
     readonly state: APIState;
     readonly onDidChangeState: Event<APIState>;
     readonly onDidPublish: Event<PublishEvent>;
@@ -265,7 +265,6 @@ export interface API {
     toGitUri(uri: Uri, ref: string): Uri;
     getRepository(uri: Uri): Repository | null;
     init(root: Uri): Promise<Repository | null>;
-    openRepository(root: Uri): Promise<Repository | null>
 
     registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable;
     registerCredentialsProvider(provider: CredentialsProvider): Disposable;
@@ -339,7 +338,7 @@ export interface GitAPI {
     readonly onDidChangeState: Event<APIState>;
     readonly onDidPublish: Event<PublishEvent>;
     readonly git: Git;
-    readonly repositories: Repository[];
+    readonly repositories: Repository[] | RemoteRepository[];
     readonly onDidOpenRepository: Event<Repository>;
     readonly onDidCloseRepository: Event<Repository>;
 
@@ -353,4 +352,19 @@ export interface GitAPI {
     registerCredentialsProvider(provider: CredentialsProvider): Disposable;
     registerPostCommitCommandsProvider(provider: PostCommitCommandsProvider): Disposable;
     registerPushErrorHandler(handler: PushErrorHandler): Disposable;
+}
+
+export interface IGit {
+    readonly repositories: Repository[];
+    readonly onDidOpenRepository: Event<Repository>;
+    readonly onDidCloseRepository: Event<Repository>;
+    openRepository(root: Uri): Promise<Repository | null>
+
+    // Used by the actual git extension to indicate it has finished initializing state information
+    readonly state?: APIState;
+    readonly metadata?: Metadata;
+    readonly onDidChangeState?: Event<APIState>;
+    readonly onDidPublish?: Event<PublishEvent>;
+
+    registerPostCommitCommandsProvider?(provider: PostCommitCommandsProvider): Disposable;
 }

--- a/src/git.d.ts
+++ b/src/git.d.ts
@@ -5,7 +5,7 @@
 
 // copied from https://github.com/microsoft/vscode/blob/master/extensions/git/src/api/git.d.ts
 import { Disposable, Event, ProviderResult, Uri } from 'vscode';
-import { Metadata, PostCommitCommandsProvider, Repository as RemoteRepository } from './rrapi';
+import { IGit } from './IGit';
 export { ProviderResult } from 'vscode';
 
 export interface Git {
@@ -253,24 +253,6 @@ export interface PublishEvent {
     branch?: string;
 }
 
-export interface API extends IGit {
-    readonly state: APIState;
-    readonly onDidChangeState: Event<APIState>;
-    readonly onDidPublish: Event<PublishEvent>;
-    readonly git: Git;
-    readonly repositories: Repository[];
-    readonly onDidOpenRepository: Event<Repository>;
-    readonly onDidCloseRepository: Event<Repository>;
-
-    toGitUri(uri: Uri, ref: string): Uri;
-    getRepository(uri: Uri): Repository | null;
-    init(root: Uri): Promise<Repository | null>;
-
-    registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable;
-    registerCredentialsProvider(provider: CredentialsProvider): Disposable;
-    registerPushErrorHandler(handler: PushErrorHandler): Disposable;
-}
-
 export interface GitExtension {
 
     readonly enabled: boolean;
@@ -286,7 +268,7 @@ export interface GitExtension {
      * @param version Version number.
      * @returns API instance
      */
-    getAPI(version: 1): API;
+    getAPI(version: 1): GitAPI;
 }
 
 export const enum GitErrorCodes {
@@ -333,14 +315,10 @@ export interface RemoteSourcePublisher {
     publishRepository(repository: Repository): Promise<void>;
 }
 
-export interface GitAPI {
+export interface GitAPI extends IGit {
     readonly state: APIState;
-    readonly onDidChangeState: Event<APIState>;
-    readonly onDidPublish: Event<PublishEvent>;
     readonly git: Git;
-    readonly repositories: Repository[] | RemoteRepository[];
-    readonly onDidOpenRepository: Event<Repository>;
-    readonly onDidCloseRepository: Event<Repository>;
+    readonly repositories: Repository[];
 
     toGitUri(uri: Uri, ref: string): Uri;
     getRepository(uri: Uri): Repository | null;
@@ -350,21 +328,5 @@ export interface GitAPI {
     registerRemoteSourcePublisher(publisher: RemoteSourcePublisher): Disposable;
     registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable;
     registerCredentialsProvider(provider: CredentialsProvider): Disposable;
-    registerPostCommitCommandsProvider(provider: PostCommitCommandsProvider): Disposable;
     registerPushErrorHandler(handler: PushErrorHandler): Disposable;
-}
-
-export interface IGit {
-    readonly repositories: Repository[];
-    readonly onDidOpenRepository: Event<Repository>;
-    readonly onDidCloseRepository: Event<Repository>;
-    openRepository(root: Uri): Promise<Repository | null>
-
-    // Used by the actual git extension to indicate it has finished initializing state information
-    readonly state?: APIState;
-    readonly metadata?: Metadata;
-    readonly onDidChangeState?: Event<APIState>;
-    readonly onDidPublish?: Event<PublishEvent>;
-
-    registerPostCommitCommandsProvider?(provider: PostCommitCommandsProvider): Disposable;
 }

--- a/src/rrapi.d.ts
+++ b/src/rrapi.d.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken, Command, Disposable, Event, Uri } from 'vscode';
-import { AzureExtensionApiProvider } from '../azext-utils-api';
-import { APIState, PublishEvent, RefType } from './git';
+import { RefType, Repository } from './git';
 
 export interface InputBox {
     value: string;
@@ -241,22 +240,7 @@ export interface PostCommitCommandsProvider {
     getCommands(repository: Repository): Command[];
 }
 
-
-export interface IGit {
-    readonly repositories: Repository[];
-    readonly onDidOpenRepository: Event<Repository>;
-    readonly onDidCloseRepository: Event<Repository>;
-
-    // Used by the actual git extension to indicate it has finished initializing state information
-    readonly state?: APIState;
-    readonly metadata?:
-    readonly onDidChangeState?: Event<APIState>;
-    readonly onDidPublish?: Event<PublishEvent>;
-
-    registerPostCommitCommandsProvider?(provider: PostCommitCommandsProvider): Disposable;
-}
-
-export interface API extends AzureExtensionApiProvider {
+export interface API {
     /**
      * Register a [git provider](#IGit)
      */
@@ -275,9 +259,9 @@ export interface RepositoryDescriptor {
     [key: string]: unknown;
 }
 
-export interface RepositoryMetadataWithPath<T extends RepositoryDescriptor = RepositoryDescriptor>
-    extends RepositoryMetadata<T> {
-    path: string;
+export interface Metadata<T extends RepositoryMetadata = RepositoryMetadata> {
+    readonly revision: string | undefined;
+    readonly cachedMetadata?: Readonly<T>;
 }
 
 export enum AccessLevel {

--- a/src/rrapi.d.ts
+++ b/src/rrapi.d.ts
@@ -1,0 +1,425 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken, Command, Disposable, Event, Uri } from 'vscode';
+import { AzureExtensionApiProvider } from '../azext-utils-api';
+import { APIState, PublishEvent, RefType } from './git';
+
+export interface InputBox {
+    value: string;
+}
+
+export { GitErrorCodes, RefType } from './RemoteRepoApi';
+
+export interface Ref {
+    readonly type: RefType;
+    readonly name?: string;
+    readonly commit?: string;
+    readonly remote?: string;
+}
+
+export interface UpstreamRef {
+    readonly remote: string;
+    readonly name: string;
+}
+
+export interface Branch extends Ref {
+    readonly upstream?: UpstreamRef;
+    readonly ahead?: number;
+    readonly behind?: number;
+}
+
+export interface Commit {
+    readonly hash: string;
+    readonly message: string;
+    readonly parents: string[];
+    readonly authorDate?: Date;
+    readonly authorName?: string;
+    readonly authorEmail?: string;
+    readonly commitDate?: Date;
+}
+
+export interface Submodule {
+    readonly name: string;
+    readonly path: string;
+    readonly url: string;
+}
+
+export interface Remote {
+    readonly name: string;
+    readonly fetchUrl?: string;
+    readonly pushUrl?: string;
+    readonly isReadOnly: boolean;
+}
+
+export const enum Status {
+    INDEX_MODIFIED,
+    INDEX_ADDED,
+    INDEX_DELETED,
+    INDEX_RENAMED,
+    INDEX_COPIED,
+
+    MODIFIED,
+    DELETED,
+    UNTRACKED,
+    IGNORED,
+    INTENT_TO_ADD,
+
+    ADDED_BY_US,
+    ADDED_BY_THEM,
+    DELETED_BY_US,
+    DELETED_BY_THEM,
+    BOTH_ADDED,
+    BOTH_DELETED,
+    BOTH_MODIFIED,
+}
+
+export interface Change {
+    /**
+     * Returns either `originalUri` or `renameUri`, depending
+     * on whether this change is a rename change. When
+     * in doubt always use `uri` over the other two alternatives.
+     */
+    readonly uri: Uri;
+    readonly originalUri: Uri;
+    readonly renameUri: Uri | undefined;
+    readonly status: Status;
+}
+
+export interface RepositoryState {
+    readonly HEAD: Branch | undefined;
+    readonly remotes: Remote[];
+    readonly submodules: Submodule[];
+    readonly rebaseCommit: Commit | undefined;
+
+    readonly mergeChanges: Change[];
+    readonly indexChanges: Change[];
+    readonly workingTreeChanges: Change[];
+
+    readonly onDidChange: Event<void>;
+}
+
+export interface RepositoryUIState {
+    readonly selected: boolean;
+    readonly onDidChange: Event<void>;
+}
+
+export interface CommitOptions {
+    all?: boolean | 'tracked';
+    amend?: boolean;
+    signoff?: boolean;
+    signCommit?: boolean;
+    empty?: boolean;
+}
+
+export interface FetchOptions {
+    remote?: string;
+    ref?: string;
+    all?: boolean;
+    prune?: boolean;
+    depth?: number;
+}
+
+export interface RefQuery {
+    readonly contains?: string;
+    readonly count?: number;
+    readonly pattern?: string;
+    readonly sort?: 'alphabetically' | 'committerdate';
+}
+
+export interface BranchQuery extends RefQuery {
+    readonly remote?: boolean;
+}
+
+export interface Repository {
+    readonly inputBox: InputBox;
+    readonly rootUri: Uri;
+    readonly state: RepositoryState;
+    readonly ui: RepositoryUIState;
+
+    /**
+     * GH PR saves pull request related information to git config when users checkout a pull request.
+     * There are two mandatory config for a branch
+     * 1. `remote`, which refers to the related github repository
+     * 2. `github-pr-owner-number`, which refers to the related pull request
+     *
+     * There is one optional config for a remote
+     * 1. `github-pr-remote`, which indicates if the remote is created particularly for GH PR review. By default, GH PR won't load pull requests from remotes created by itself (`github-pr-remote=true`).
+     *
+     * Sample config:
+     * ```git
+     * [remote "pr"]
+     * url = https://github.com/pr/vscode-pull-request-github
+     * fetch = +refs/heads/*:refs/remotes/pr/*
+     * github-pr-remote = true
+     * [branch "fix-123"]
+     * remote = pr
+     * merge = refs/heads/fix-123
+     * github-pr-owner-number = "Microsoft#vscode-pull-request-github#123"
+     * ```
+     */
+    getConfigs(): Promise<{ key: string; value: string }[]>;
+
+    /**
+     * Git providers are recommended to implement a minimal key value lookup for git config but you can only provide config for following keys to activate GH PR successfully
+     * 1. `branch.${branchName}.github-pr-owner-number`
+     * 2. `remote.${remoteName}.github-pr-remote`
+     * 3. `branch.${branchName}.remote`
+     */
+    getConfig(key: string): Promise<string>;
+
+    /**
+     * The counterpart of `getConfig`
+     */
+    setConfig(key: string, value: string): Promise<string>;
+    getGlobalConfig(key: string): Promise<string>;
+
+    getObjectDetails(treeish: string, path: string): Promise<{ mode: string; object: string; size: number }>;
+    detectObjectType(object: string): Promise<{ mimetype: string; encoding?: string }>;
+    buffer(ref: string, path: string): Promise<Buffer>;
+    show(ref: string, path: string): Promise<string>;
+    getCommit(ref: string): Promise<Commit>;
+
+    clean(paths: string[]): Promise<void>;
+
+    apply(patch: string, reverse?: boolean): Promise<void>;
+    diff(cached?: boolean): Promise<string>;
+    diffWithHEAD(): Promise<Change[]>;
+    diffWithHEAD(path: string): Promise<string>;
+    diffWith(ref: string): Promise<Change[]>;
+    diffWith(ref: string, path: string): Promise<string>;
+    diffIndexWithHEAD(): Promise<Change[]>;
+    diffIndexWithHEAD(path: string): Promise<string>;
+    diffIndexWith(ref: string): Promise<Change[]>;
+    diffIndexWith(ref: string, path: string): Promise<string>;
+    diffBlobs(object1: string, object2: string): Promise<string>;
+    diffBetween(ref1: string, ref2: string): Promise<Change[]>;
+    diffBetween(ref1: string, ref2: string, path: string): Promise<string>;
+
+    hashObject(data: string): Promise<string>;
+
+    createBranch(name: string, checkout: boolean, ref?: string): Promise<void>;
+    deleteBranch(name: string, force?: boolean): Promise<void>;
+    getBranch(name: string): Promise<Branch>;
+    getBranches(query: BranchQuery): Promise<Ref[]>;
+    setBranchUpstream(name: string, upstream: string): Promise<void>;
+    getRefs(query: RefQuery, cancellationToken?: CancellationToken): Promise<Ref[]>;
+
+    getMergeBase(ref1: string, ref2: string): Promise<string>;
+
+    status(): Promise<void>;
+    checkout(treeish: string): Promise<void>;
+
+    addRemote(name: string, url: string): Promise<void>;
+    removeRemote(name: string): Promise<void>;
+    renameRemote(name: string, newName: string): Promise<void>;
+
+    fetch(options?: FetchOptions): Promise<void>;
+    fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
+    pull(unshallow?: boolean): Promise<void>;
+    push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
+
+    blame(path: string): Promise<string>;
+    log(options?: LogOptions): Promise<Commit[]>;
+
+    commit(message: string, opts?: CommitOptions): Promise<void>;
+    add(paths: string[]): Promise<void>;
+}
+
+/**
+ * Log options.
+ */
+export interface LogOptions {
+    /** Max number of log entries to retrieve. If not specified, the default is 32. */
+    readonly maxEntries?: number;
+    readonly path?: string;
+}
+
+export interface PostCommitCommandsProvider {
+    getCommands(repository: Repository): Command[];
+}
+
+
+export interface IGit {
+    readonly repositories: Repository[];
+    readonly onDidOpenRepository: Event<Repository>;
+    readonly onDidCloseRepository: Event<Repository>;
+
+    // Used by the actual git extension to indicate it has finished initializing state information
+    readonly state?: APIState;
+    readonly metadata?:
+    readonly onDidChangeState?: Event<APIState>;
+    readonly onDidPublish?: Event<PublishEvent>;
+
+    registerPostCommitCommandsProvider?(provider: PostCommitCommandsProvider): Disposable;
+}
+
+export interface API extends AzureExtensionApiProvider {
+    /**
+     * Register a [git provider](#IGit)
+     */
+    registerGitProvider(provider: IGit): Disposable;
+
+    /**
+     * Returns the [git provider](#IGit) that contains a given uri.
+     *
+     * @param uri An uri.
+     * @return A git provider or `undefined`
+     */
+    getGitProvider(uri: Uri): IGit | undefined;
+}
+
+export interface RepositoryDescriptor {
+    [key: string]: unknown;
+}
+
+export interface RepositoryMetadataWithPath<T extends RepositoryDescriptor = RepositoryDescriptor>
+    extends RepositoryMetadata<T> {
+    path: string;
+}
+
+export enum AccessLevel {
+    Admin = 100,
+    Maintain = 40,
+    WriteToPullRequest = 31,
+    Write = 30,
+    Triage = 20,
+    Read = 10,
+    None = 0,
+}
+
+export enum HeadType {
+    Branch = 0,
+    RemoteBranch = 1,
+    Tag = 2,
+    Commit = 3,
+}
+
+export const enum PullRequestState {
+    /** A pull request that is still open. */
+    Open = 0,
+    /** A pull request that has been closed without being merged. */
+    Closed = 1,
+    /** A pull request that has been closed by being merged. */
+    Merged = 2,
+}
+
+export interface IncomingChange {
+    uri: Uri;
+    type: OperationType;
+}
+
+export enum OperationType {
+    Changed = 1, // FileChangeType.Changed
+    Created = 2, // FileChangeType.Created
+    Deleted = 3, // FileChangeType.Deleted
+}
+/**
+ * Metadata which associates a specific root uri to a repository
+ * Must be JSON.stringify/JSON.parse -able
+ */
+export interface RepositoryMetadata<T extends RepositoryDescriptor = RepositoryDescriptor> {
+    /** The version number of the metadata schema. Used for metadata discard/refresh or migration */
+    version: 6;
+    /** The timestamp for when this metadata was last updated */
+    timestamp: number;
+    /** The remote provider for the repository */
+    provider: { id: string; name: string };
+
+    /** A user-friendly repository name */
+    name: string;
+    /** A provider-defined descriptor of the repository */
+    repo: T;
+
+    /** The current user's repository access level */
+    accessLevel: AccessLevel;
+    /** The current HEAD */
+    HEAD:
+    | {
+        /** The type of the current HEAD */
+        type: HeadType.Branch;
+        /** The friendly name of the current branch */
+        name: string;
+        /** The current HEAD commit SHA */
+        sha: string;
+        detached?: undefined;
+        /** The current branch including the branch's tip SHA */
+        branch: {
+            name: string;
+            sha: string;
+            remote?: undefined;
+        };
+    }
+    | {
+        /** The type of the current HEAD */
+        type: HeadType.RemoteBranch;
+        /** The friendly name of the current remote branch */
+        name: string;
+        /** The current HEAD commit SHA */
+        sha: string;
+        detached?: undefined;
+        /** The current branch including the branch's tip SHA */
+        branch: {
+            name: string;
+            sha: string;
+            remote: {
+                name: string;
+                accessLevel: AccessLevel;
+                repo: T;
+            };
+        };
+    }
+    | {
+        /** The type of the current detached HEAD */
+        type: HeadType.Tag;
+        /** The friendly name of the current detached HEAD */
+        name: string;
+        /** The current HEAD commit SHA */
+        sha: string;
+        /** Indicates if the current HEAD is detached (e.g. not on a branch) */
+        detached: {
+            type: HeadType.Tag;
+            name: string;
+        };
+        branch?: undefined;
+    }
+    | {
+        /** The type of the current detached HEAD */
+        type: HeadType.Commit;
+        /** The friendly name of the current detached HEAD */
+        name: string;
+        /** The current HEAD commit SHA */
+        sha: string;
+        /** Indicates if the current HEAD is detached (e.g. not on a branch) */
+        detached: {
+            type: HeadType.Commit;
+            name: string;
+        };
+        branch?: undefined;
+    };
+    /** The repository's default branch including the branch's tip SHA */
+    defaultBranch: {
+        name: string;
+        sha: string;
+    };
+    /** Optional. The pull request, if the repository was opened to a pull request */
+    pullRequest?: {
+        id: string;
+        state: PullRequestState;
+        title: string;
+    };
+    // /** The current SHA */
+    // sha: string;
+    /** Optional. The current state (think `git status`) of the current branch/SHA to the upstream */
+    state?: {
+        ahead: number;
+        behind: number;
+        incomingChanges: IncomingChange[];
+    };
+    cloneUrl: {
+        http: string;
+        ssh: string;
+    }
+}

--- a/src/rrapi.d.ts
+++ b/src/rrapi.d.ts
@@ -11,8 +11,6 @@ export interface InputBox {
     value: string;
 }
 
-export { GitErrorCodes, RefType } from './RemoteRepoApi';
-
 // unique to Remote Repositories API
 export interface RefQuery {
     readonly contains?: string;

--- a/src/rrapi.d.ts
+++ b/src/rrapi.d.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken, Command, Disposable, Event, Uri } from 'vscode';
-import { RefType, Repository } from './git';
+import { CancellationToken, Command, Disposable, Uri } from 'vscode';
+import { IGit } from './IGit';
+import { Ref, Repository } from './git';
 
 export interface InputBox {
     value: string;
@@ -12,115 +13,7 @@ export interface InputBox {
 
 export { GitErrorCodes, RefType } from './RemoteRepoApi';
 
-export interface Ref {
-    readonly type: RefType;
-    readonly name?: string;
-    readonly commit?: string;
-    readonly remote?: string;
-}
-
-export interface UpstreamRef {
-    readonly remote: string;
-    readonly name: string;
-}
-
-export interface Branch extends Ref {
-    readonly upstream?: UpstreamRef;
-    readonly ahead?: number;
-    readonly behind?: number;
-}
-
-export interface Commit {
-    readonly hash: string;
-    readonly message: string;
-    readonly parents: string[];
-    readonly authorDate?: Date;
-    readonly authorName?: string;
-    readonly authorEmail?: string;
-    readonly commitDate?: Date;
-}
-
-export interface Submodule {
-    readonly name: string;
-    readonly path: string;
-    readonly url: string;
-}
-
-export interface Remote {
-    readonly name: string;
-    readonly fetchUrl?: string;
-    readonly pushUrl?: string;
-    readonly isReadOnly: boolean;
-}
-
-export const enum Status {
-    INDEX_MODIFIED,
-    INDEX_ADDED,
-    INDEX_DELETED,
-    INDEX_RENAMED,
-    INDEX_COPIED,
-
-    MODIFIED,
-    DELETED,
-    UNTRACKED,
-    IGNORED,
-    INTENT_TO_ADD,
-
-    ADDED_BY_US,
-    ADDED_BY_THEM,
-    DELETED_BY_US,
-    DELETED_BY_THEM,
-    BOTH_ADDED,
-    BOTH_DELETED,
-    BOTH_MODIFIED,
-}
-
-export interface Change {
-    /**
-     * Returns either `originalUri` or `renameUri`, depending
-     * on whether this change is a rename change. When
-     * in doubt always use `uri` over the other two alternatives.
-     */
-    readonly uri: Uri;
-    readonly originalUri: Uri;
-    readonly renameUri: Uri | undefined;
-    readonly status: Status;
-}
-
-export interface RepositoryState {
-    readonly HEAD: Branch | undefined;
-    readonly remotes: Remote[];
-    readonly submodules: Submodule[];
-    readonly rebaseCommit: Commit | undefined;
-
-    readonly mergeChanges: Change[];
-    readonly indexChanges: Change[];
-    readonly workingTreeChanges: Change[];
-
-    readonly onDidChange: Event<void>;
-}
-
-export interface RepositoryUIState {
-    readonly selected: boolean;
-    readonly onDidChange: Event<void>;
-}
-
-export interface CommitOptions {
-    all?: boolean | 'tracked';
-    amend?: boolean;
-    signoff?: boolean;
-    signCommit?: boolean;
-    empty?: boolean;
-}
-
-export interface FetchOptions {
-    remote?: string;
-    ref?: string;
-    all?: boolean;
-    prune?: boolean;
-    depth?: number;
-}
-
+// unique to Remote Repositories API
 export interface RefQuery {
     readonly contains?: string;
     readonly count?: number;
@@ -128,112 +21,9 @@ export interface RefQuery {
     readonly sort?: 'alphabetically' | 'committerdate';
 }
 
-export interface BranchQuery extends RefQuery {
-    readonly remote?: boolean;
-}
-
-export interface Repository {
-    readonly inputBox: InputBox;
-    readonly rootUri: Uri;
-    readonly state: RepositoryState;
-    readonly ui: RepositoryUIState;
-
-    /**
-     * GH PR saves pull request related information to git config when users checkout a pull request.
-     * There are two mandatory config for a branch
-     * 1. `remote`, which refers to the related github repository
-     * 2. `github-pr-owner-number`, which refers to the related pull request
-     *
-     * There is one optional config for a remote
-     * 1. `github-pr-remote`, which indicates if the remote is created particularly for GH PR review. By default, GH PR won't load pull requests from remotes created by itself (`github-pr-remote=true`).
-     *
-     * Sample config:
-     * ```git
-     * [remote "pr"]
-     * url = https://github.com/pr/vscode-pull-request-github
-     * fetch = +refs/heads/*:refs/remotes/pr/*
-     * github-pr-remote = true
-     * [branch "fix-123"]
-     * remote = pr
-     * merge = refs/heads/fix-123
-     * github-pr-owner-number = "Microsoft#vscode-pull-request-github#123"
-     * ```
-     */
-    getConfigs(): Promise<{ key: string; value: string }[]>;
-
-    /**
-     * Git providers are recommended to implement a minimal key value lookup for git config but you can only provide config for following keys to activate GH PR successfully
-     * 1. `branch.${branchName}.github-pr-owner-number`
-     * 2. `remote.${remoteName}.github-pr-remote`
-     * 3. `branch.${branchName}.remote`
-     */
-    getConfig(key: string): Promise<string>;
-
-    /**
-     * The counterpart of `getConfig`
-     */
-    setConfig(key: string, value: string): Promise<string>;
-    getGlobalConfig(key: string): Promise<string>;
-
-    getObjectDetails(treeish: string, path: string): Promise<{ mode: string; object: string; size: number }>;
-    detectObjectType(object: string): Promise<{ mimetype: string; encoding?: string }>;
-    buffer(ref: string, path: string): Promise<Buffer>;
-    show(ref: string, path: string): Promise<string>;
-    getCommit(ref: string): Promise<Commit>;
-
-    clean(paths: string[]): Promise<void>;
-
-    apply(patch: string, reverse?: boolean): Promise<void>;
-    diff(cached?: boolean): Promise<string>;
-    diffWithHEAD(): Promise<Change[]>;
-    diffWithHEAD(path: string): Promise<string>;
-    diffWith(ref: string): Promise<Change[]>;
-    diffWith(ref: string, path: string): Promise<string>;
-    diffIndexWithHEAD(): Promise<Change[]>;
-    diffIndexWithHEAD(path: string): Promise<string>;
-    diffIndexWith(ref: string): Promise<Change[]>;
-    diffIndexWith(ref: string, path: string): Promise<string>;
-    diffBlobs(object1: string, object2: string): Promise<string>;
-    diffBetween(ref1: string, ref2: string): Promise<Change[]>;
-    diffBetween(ref1: string, ref2: string, path: string): Promise<string>;
-
-    hashObject(data: string): Promise<string>;
-
-    createBranch(name: string, checkout: boolean, ref?: string): Promise<void>;
-    deleteBranch(name: string, force?: boolean): Promise<void>;
-    getBranch(name: string): Promise<Branch>;
-    getBranches(query: BranchQuery): Promise<Ref[]>;
-    setBranchUpstream(name: string, upstream: string): Promise<void>;
-    getRefs(query: RefQuery, cancellationToken?: CancellationToken): Promise<Ref[]>;
-
-    getMergeBase(ref1: string, ref2: string): Promise<string>;
-
-    status(): Promise<void>;
-    checkout(treeish: string): Promise<void>;
-
-    addRemote(name: string, url: string): Promise<void>;
-    removeRemote(name: string): Promise<void>;
-    renameRemote(name: string, newName: string): Promise<void>;
-
-    fetch(options?: FetchOptions): Promise<void>;
-    fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
-    pull(unshallow?: boolean): Promise<void>;
-    push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
-
-    blame(path: string): Promise<string>;
-    log(options?: LogOptions): Promise<Commit[]>;
-
-    commit(message: string, opts?: CommitOptions): Promise<void>;
-    add(paths: string[]): Promise<void>;
-}
-
-/**
- * Log options.
- */
-export interface LogOptions {
-    /** Max number of log entries to retrieve. If not specified, the default is 32. */
-    readonly maxEntries?: number;
-    readonly path?: string;
+export interface RemoteRepository extends Repository {
+    getRefs?(query: RefQuery, cancellationToken?: CancellationToken): Promise<Ref[]>;
+    add?(paths: string[]): Promise<void>;
 }
 
 export interface PostCommitCommandsProvider {

--- a/src/tree/EnvironmentTreeItem.ts
+++ b/src/tree/EnvironmentTreeItem.ts
@@ -6,7 +6,7 @@
 import { StaticSiteBuildARMResource, WebSiteManagementClient } from "@azure/arm-appservice";
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath, nonNullProp } from "@microsoft/vscode-azext-utils";
 import { ResolvedAppResourceTreeItem } from "@microsoft/vscode-azext-utils/hostapi";
-import { ProgressLocation, ThemeIcon, window } from "vscode";
+import { ProgressLocation, ThemeIcon, Uri, window } from "vscode";
 import { ResolvedStaticWebApp } from "../StaticWebAppResolver";
 import { SwaAppSettingsClientProvider } from "../commands/appSettings/AppSettingsClient";
 import { onlyGitHubSupported, productionEnvironmentName } from "../constants";
@@ -47,7 +47,7 @@ export class EnvironmentTreeItem extends AzExtParentTreeItem implements IAzureRe
     public repositoryUrl: string;
     public branch: string;
     public buildId: string;
-    public localProjectPath: string | undefined;
+    public localProjectPath: Uri | undefined;
 
     public isProduction: boolean;
     public inWorkspace!: boolean;

--- a/src/tree/WorkflowGroupTreeItem.ts
+++ b/src/tree/WorkflowGroupTreeItem.ts
@@ -67,7 +67,8 @@ export class WorkflowGroupTreeItem extends AzExtParentTreeItem {
         const treeItems: WorkflowGroupTreeItem[] = [];
 
         if (parent.localProjectPath && parent.inWorkspace) {
-            const workflowsDir: string = join(parent.localProjectPath, '.github/workflows');
+            // TODO: Change to Uri utils
+            const workflowsDir: string = join(parent.localProjectPath.fsPath, '.github/workflows');
             const yamlFiles: string[] = await AzExtFsExtra.pathExists(workflowsDir) ?
                 (await workspace.fs.readDirectory(Uri.file(workflowsDir))).filter(file => file[1] === FileType.File && /\.(yml|yaml)$/i.test(file[0])).map(file => file[0]) :
                 [];

--- a/src/tree/WorkflowGroupTreeItem.ts
+++ b/src/tree/WorkflowGroupTreeItem.ts
@@ -5,13 +5,15 @@
 
 import { AzExtFsExtra, AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, parseError, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { basename, join } from "path";
-import { FileType, Range, ThemeIcon, Uri, workspace } from "vscode";
+import { FileType, Range, ThemeIcon, workspace } from "vscode";
 // eslint-disable-next-line import/no-internal-modules
+import { URI, Utils } from "vscode-uri";
 import { YAMLError } from "yaml";
 import { localize } from "../utils/localize";
 import { parseYamlFile } from "../utils/yamlUtils";
 import { EnvironmentTreeItem } from "./EnvironmentTreeItem";
 import { WorkflowTreeItem } from "./WorkflowTreeItem";
+
 
 export type BuildConfig = 'app_location' | 'api_location' | 'output_location' | 'app_artifact_location';
 
@@ -67,16 +69,15 @@ export class WorkflowGroupTreeItem extends AzExtParentTreeItem {
         const treeItems: WorkflowGroupTreeItem[] = [];
 
         if (parent.localProjectPath && parent.inWorkspace) {
-            // TODO: Change to Uri utils
-            const workflowsDir: string = join(parent.localProjectPath.fsPath, '.github/workflows');
+            const workflowsDir: URI = Utils.joinPath(parent.localProjectPath, '.github/workflows');
             const yamlFiles: string[] = await AzExtFsExtra.pathExists(workflowsDir) ?
-                (await workspace.fs.readDirectory(Uri.file(workflowsDir))).filter(file => file[1] === FileType.File && /\.(yml|yaml)$/i.test(file[0])).map(file => file[0]) :
+                (await workspace.fs.readDirectory(workflowsDir)).filter(file => file[1] === FileType.File && /\.(yml|yaml)$/i.test(file[0])).map(file => file[0]) :
                 [];
 
             context.telemetry.properties.numWorkflows = yamlFiles.length.toString();
 
             for (const yamlFile of yamlFiles) {
-                const ti = new WorkflowGroupTreeItem(parent, join(workflowsDir, yamlFile));
+                const ti = new WorkflowGroupTreeItem(parent, join(workflowsDir.fsPath, yamlFile));
                 await ti.refreshImpl(context);
                 treeItems.push(ti);
             }

--- a/src/utils/gitHubUtils.ts
+++ b/src/utils/gitHubUtils.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, IAzureQuickPickItem, nonNullProp, parseError, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { Octokit } from '@octokit/rest';
-import { authentication, ProgressLocation, window } from 'vscode';
+import { authentication, ProgressLocation, Uri, window } from 'vscode';
 import { createOctokitClient } from '../commands/github/createOctokitClient';
 import { githubAuthProviderId, githubScopes } from '../constants';
 import { ext } from '../extensionVariables';
@@ -65,7 +65,7 @@ export function hasAdminAccessToRepo(repoData?: ReposGetResponseData): boolean {
     return !!repoData?.permissions?.admin
 }
 
-export async function tryGetRepoDataForCreation(context: IActionContext, localProjectPath?: string): Promise<ReposGetResponseData | undefined> {
+export async function tryGetRepoDataForCreation(context: IActionContext, localProjectPath?: Uri): Promise<ReposGetResponseData | undefined> {
     const originUrl: string | undefined = await tryGetRemote(localProjectPath);
     if (originUrl) {
         const repoData: ReposGetResponseData | undefined = await tryGetReposGetResponseData(context, originUrl);

--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -5,8 +5,8 @@
 
 import { AzExtFsExtra, IActionContext, nonNullValue, UserCancelledError } from "@microsoft/vscode-azext-utils";
 import * as gitUrlParse from 'git-url-parse';
-import { join } from 'path';
 import { MessageItem, ProgressLocation, ProgressOptions, Uri, window, workspace } from 'vscode';
+import { Utils } from "vscode-uri";
 import { IStaticWebAppWizardContext } from "../commands/createStaticWebApp/IStaticWebAppWizardContext";
 import { cloneRepo } from '../commands/github/cloneRepo';
 import { defaultGitignoreContents, gitignoreFileName } from '../constants';
@@ -86,7 +86,7 @@ export async function verifyGitWorkspaceForCreation(context: IActionContext, git
         }
 
         // create a generic .gitignore for user if we do not detect one
-        const gitignorePath: string = join(uri.fsPath, gitignoreFileName);
+        const gitignorePath: Uri = Utils.joinPath(uri, gitignoreFileName);
         if (!await AzExtFsExtra.pathExists(gitignorePath)) {
             await AzExtFsExtra.writeFile(gitignorePath, defaultGitignoreContents);
         }

--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -160,8 +160,6 @@ async function promptForCommit(context: IActionContext, repo: Repository, value?
     const commitMsg: string = await context.ui.showInputBox({ prompt: commitPrompt, placeHolder: `${commitPrompt}..`, value, stepName });
     try {
         await repo.commit(commitMsg, commitOptions);
-        // doesn't seem to work when called directly
-        // await commands.executeCommand('remoteHub.commit', repo.sourceControl);
     } catch (err) {
         handleGitError(err);
     }

--- a/src/utils/settingsUtils.ts
+++ b/src/utils/settingsUtils.ts
@@ -9,16 +9,16 @@ import { ext } from "../extensionVariables";
 /**
  * Uses ext.prefix 'staticWebApps' unless otherwise specified
  */
-export async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string, prefix: string = ext.prefix): Promise<void> {
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, Uri.file(fsPath));
+export async function updateWorkspaceSetting<T = string>(section: string, value: T, uri: Uri, prefix: string = ext.prefix): Promise<void> {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, uri);
     await projectConfiguration.update(section, value);
 }
 
 /**
  * Uses ext.prefix 'staticWebApps' unless otherwise specified
  */
-export function getWorkspaceSetting<T>(key: string, fsPath?: string, prefix: string = ext.prefix): T | undefined {
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, fsPath ? Uri.file(fsPath) : undefined);
+export function getWorkspaceSetting<T>(key: string, uri?: Uri, prefix: string = ext.prefix): T | undefined {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, uri);
     return projectConfiguration.get<T>(key);
 }
 

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
 import * as path from 'path';
-import { commands, FileType, MessageItem, OpenDialogOptions, Uri, workspace, WorkspaceFolder } from "vscode";
+import { FileType, MessageItem, OpenDialogOptions, Uri, WorkspaceFolder, commands, workspace } from "vscode";
 import { cloneRepo } from '../commands/github/cloneRepo';
 import { openExistingProject } from '../constants';
 import { NoWorkspaceError } from '../errors';
@@ -16,9 +16,9 @@ export function isMultiRootWorkspace(): boolean {
         && workspace.name !== workspace.workspaceFolders[0].name; // multi-root workspaces always have something like "(Workspace)" appended to their name
 }
 
-export function getSingleRootFsPath(): string | undefined {
+export function getSingleRootFsPath(): Uri | undefined {
     // if this is no workspace or a multi-root workspace, return undefined
-    return workspace.workspaceFolders && workspace.workspaceFolders.length === 1 ? workspace.workspaceFolders[0].uri.fsPath : undefined;
+    return workspace.workspaceFolders && workspace.workspaceFolders.length === 1 ? workspace.workspaceFolders[0].uri : undefined;
 }
 
 export async function selectWorkspaceFolder(context: IActionContext, placeHolder: string, getSubPath?: (f: WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,9 @@ let config = dev.getDefaultWebpackConfig({
     },
     plugins: [new webpack.ProvidePlugin({
         process: 'process/browser.js'
+    }),
+    new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
     })]
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,23 @@ const webpack = require('webpack');
 
 let DEBUG_WEBPACK = !/^(false|0)?$/i.test(process.env.DEBUG_WEBPACK || '');
 
-let config = dev.getDefaultWebpackConfig({
+let nodeConfig = dev.getDefaultWebpackConfig({
+    projectRoot: __dirname,
+    verbosity: DEBUG_WEBPACK ? 'debug' : 'normal',
+    externals:
+    {
+        // Fix "Module not found" errors in ./node_modules/websocket/lib/{BufferUtil,Validation}.js
+        // These files are not in node_modules and so will fail normally at runtime and instead use fallbacks.
+        // Make them as external so webpack doesn't try to process them, and they'll simply fail at runtime as before.
+        '../build/Release/validation': 'commonjs ../build/Release/validation',
+        '../build/default/validation': 'commonjs ../build/default/validation',
+        '../build/Release/bufferutil': 'commonjs ../build/Release/bufferutil',
+        '../build/default/bufferutil': 'commonjs ../build/default/bufferutil',
+    },
+    target: 'node'
+});
+
+let webConfig = dev.getDefaultWebpackConfig({
     projectRoot: __dirname,
     verbosity: DEBUG_WEBPACK ? 'debug' : 'normal',
     externals:
@@ -42,7 +58,7 @@ let config = dev.getDefaultWebpackConfig({
 });
 
 if (DEBUG_WEBPACK) {
-    console.log('Config:', config);
+    console.log('Config:', nodeConfig);
 }
 
-module.exports = config;
+module.exports = [nodeConfig, webConfig];


### PR DESCRIPTION
Remote Repositories lets users open GitHub repos in vscode.dev or in a virtual workspace. By leveraging their API, I was able to basically enable full SWA create support on vscode.dev with minimal refactoring.

There are a lot of files related to the git API, but I will move them in another PR since it would make reviewing changes a pain.

`path.join` won't work in vscode.dev, so I replaced it where relevant. `createHttpFunction` still uses it since it can only be used on desktop, though we can probably just remove it all eventually.