### PR TITLE
Disable create config

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,8 @@
             {
                 "command": "staticWebApps.createSwaConfigFile",
                 "title": "%staticWebApps.createSwaConfigFile%",
-                "category": "Azure Static Web Apps"
+                "category": "Azure Static Web Apps",
+                "enablement": "!isWeb"
             },
             {
                 "command": "staticWebApps.deleteEnvironment",

--- a/src/commands/createSwaConfigFile.ts
+++ b/src/commands/createSwaConfigFile.ts
@@ -11,8 +11,8 @@ import { localize } from '../utils/localize';
 import { selectWorkspaceFolder } from '../utils/workspaceUtils';
 
 export async function createSwaConfigFile(context: IActionContext): Promise<void> {
-    const destPath: string = await selectWorkspaceFolder(context, localize('selectConfigFileLocation', 'Select location to create "{0}"', configFileName));
-    const configFilePath: URI = Utils.joinPath(URI.parse(destPath), configFileName);
+    const destPath: URI = await selectWorkspaceFolder(context, localize('selectConfigFileLocation', 'Select location to create "{0}"', configFileName));
+    const configFilePath: URI = Utils.joinPath(destPath, configFileName);
 
     if (await AzExtFsExtra.pathExists(configFilePath)) {
         const configFileExists: string = localize('configFileExists', 'Static Web App configuration file "{0}" already exists.', configFilePath.fsPath);


### PR DESCRIPTION
In Web, local directories require special permissions to create files.

We could probably do this for remote repositories, but probably don't have the time for it. It's not super useful without being able to debug anyway.