### PR TITLE
Activate RemoteRepo if local git is disabled. Also always use RemoteRepos for web

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ import { MessageItem } from "vscode";
 import { localize } from "./utils/localize";
 
 export const githubApiEndpoint: string = 'https://api.github.com';
+export const remoteRepositoriesId: string = 'ms-vscode.remote-repositories';
 
 export const defaultAppLocation: string = '/';
 export const defaultApiLocation: string = 'api';

--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -52,7 +52,10 @@ export async function getGitApi(): Promise<IGit> {
             return ext.remoteRepoApi;
         }
     } catch (err) {
-        if (!getWorkspaceSetting<boolean>('enabled', undefined, 'git')) {
+        // if there is no local git, but remote repo is installed, then use that
+        if (await getApiExport(remoteRepositoriesId)) {
+            return ext.remoteRepoApi;
+        } else if (!getWorkspaceSetting<boolean>('enabled', undefined, 'git')) {
             // the getExtension error is very vague and unactionable so throw our own error if git isn't enabled
             throw new Error(localize('gitEnabled', 'If you would like to use git features, please enable git in your [settings](command:workbench.action.openSettings?%5B%22git.enabled%22%5D). To learn more about how to use git and source control in VS Code [read our docs](https://aka.ms/vscode-scm).'));
         } else {

--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -8,6 +8,7 @@ import { AzureHostExtensionApi } from "@microsoft/vscode-azext-utils/hostapi";
 import { apiUtils } from '@microsoft/vscode-azureresources-api';
 import { Extension, commands, extensions } from "vscode";
 import { IGit } from "./IGit";
+import { remoteRepositoriesId } from "./constants";
 import { ext } from "./extensionVariables";
 import { GitExtension } from "./git";
 import { localize } from "./utils/localize";

--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -9,7 +9,7 @@ import { commands, env, MessageItem, ProgressLocation, ProgressOptions, UIKind, 
 import { Utils } from "vscode-uri";
 import { IStaticWebAppWizardContext } from "../commands/createStaticWebApp/IStaticWebAppWizardContext";
 import { cloneRepo } from '../commands/github/cloneRepo';
-import { defaultGitignoreContents, gitignoreFileName, openRemoteProjectMsg } from '../constants';
+import { defaultGitignoreContents, gitignoreFileName, openRemoteProjectMsg, remoteRepositoriesId } from '../constants';
 import { handleGitError } from '../errors';
 import { ext } from "../extensionVariables";
 import { getApiExport, getGitApi } from "../getExtensionApi";

--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -23,16 +23,9 @@ import { getSingleRootFsPath } from './workspaceUtils';
 export type GitWorkspaceState = { repo: Repository | null, dirty: boolean, remoteRepo: ReposGetResponseData | undefined; hasAdminAccess: boolean };
 export type VerifiedGitWorkspaceState = GitWorkspaceState & { repo: Repository };
 
+const isWeb: boolean = env.uiKind === UIKind.Web;
+
 export async function getGitWorkspaceState(context: IActionContext & Partial<IStaticWebAppWizardContext>, uri: Uri): Promise<GitWorkspaceState> {
-    // this is where we would have a split in logic
-    // check if there is a remote repo opened (this can be in web or desktop)
-    // if not, then we can check if there is a local repo opened
-    // if we have access to git, we should use this method
-
-    // how to refactor?
-    // we could either have two totally separate methods or select the logic based on the context
-    // having separate methods might be a little cleaner, but it would be a lot of duplicated code
-
     const gitWorkspaceState: GitWorkspaceState = { repo: null, dirty: false, remoteRepo: undefined, hasAdminAccess: false };
     const gitApi: IGit = await getGitApi();
     let repo: Repository | null = null;
@@ -69,6 +62,14 @@ export async function verifyGitWorkspaceForCreation(context: IActionContext, git
     let repo: Repository | null = gitWorkspaceState.repo;
 
     if (!gitWorkspaceState.repo) {
+        if (isWeb) {
+            const remoteRepoRequired: string = localize('remoteRepoRequired', 'A GitHub repository is required to proceed. Open a remote repository?');
+            await context.ui.showWarningMessage(remoteRepoRequired, { modal: true, stepName: 'openRemoteRepo' }, { title: localize('open', 'Open') });
+            // if they're in web, remote repo is installed
+            await commands.executeCommand('remoteHub.openRepository');
+            throw new UserCancelledError('openedRemoteRepo');
+        }
+
         const gitRequired: string = localize('gitRequired', 'A GitHub repository is required to proceed. Create a local git repository and GitHub remote to create a Static Web App.');
 
         await context.ui.showWarningMessage(gitRequired, { modal: true, stepName: 'initRepo' }, { title: localize('create', 'Create') });
@@ -106,12 +107,12 @@ export async function verifyGitWorkspaceForCreation(context: IActionContext, git
         const buttons: MessageItem[] = [];
         const clone: MessageItem = { title: localize('clone', 'Clone Repo') };
 
-        if (env.uiKind === UIKind.Desktop) {
+        if (!isWeb) {
             forkSuccess += localize('cloneNewRepo', ' Would you like to clone your new repository?');
             buttons.push(clone);
         }
 
-        if (await getApiExport('ms-vscode.remote-repositories')) {
+        if (await getApiExport(remoteRepositoriesId)) {
             buttons.push(openRemoteProjectMsg)
         }
 

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -81,7 +81,7 @@ export async function showNoWorkspacePrompt(context: IActionContext): Promise<vo
         buttons.push(cloneProjectMsg, openExistingProjectMsg);
     }
 
-    if (await getApiExport('ms-vscode.remote-repositories')) {
+    if (await getApiExport(remoteRepositoriesId)) {
         buttons.push(openRemoteProjectMsg);
     }
 

--- a/src/utils/workspaceUtils.ts
+++ b/src/utils/workspaceUtils.ts
@@ -7,7 +7,7 @@ import { IActionContext, IAzureQuickPickItem } from "@microsoft/vscode-azext-uti
 import * as path from 'path';
 import { FileType, MessageItem, OpenDialogOptions, Uri, WorkspaceFolder, commands, workspace } from "vscode";
 import { cloneRepo } from '../commands/github/cloneRepo';
-import { openExistingProject, openRemoteProjectMsg } from '../constants';
+import { openExistingProject, openRemoteProjectMsg, remoteRepositoriesId } from '../constants';
 import { NoWorkspaceError } from '../errors';
 import { getApiExport } from "../getExtensionApi";
 import { localize } from "./localize";


### PR DESCRIPTION
In a web environment, if you had a local workspace opened without a repo (which is always the case in web since we don't have access to their git), the extension tries to use local git to create a new repo which fails. 

This changes it so that it will always prompt the user to open a remote repository.

Honestly, the SWA extension could use a nice refactor. This is definitely something that I will revisit now that I know how webpack works a lot better. The codeflow is also not great to separate into desktop and web right now, so some work will have to be done for that as well.