### PR TITLE
Change minimum VS Code version to 1.82.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "@types/mocha": "^8.2.2",
                 "@types/node": "^16.18.36",
                 "@types/semver": "^7.3.8",
-                "@types/vscode": "^1.86.0",
+                "@types/vscode": "^1.82.0",
                 "@typescript-eslint/eslint-plugin": "^5.59.11",
                 "@vscode/test-electron": "^2.3.8",
                 "@vscode/vsce": "^2.19.0",
@@ -54,7 +54,7 @@
                 "webpack-cli": "^4.6.0"
             },
             "engines": {
-                "vscode": "^1.76.0"
+                "vscode": "^1.86.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1082,9 +1082,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.86.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
-            "integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
+            "version": "1.82.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+            "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/azure-staticwebapps.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "engines": {
-        "vscode": "^1.86.0"
+        "vscode": "^1.82.0"
     },
     "repository": {
         "type": "git",
@@ -474,7 +474,7 @@
         "@types/mocha": "^8.2.2",
         "@types/node": "^16.18.36",
         "@types/semver": "^7.3.8",
-        "@types/vscode": "^1.86.0",
+        "@types/vscode": "^1.82.0",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@vscode/test-electron": "^2.3.8",
         "@vscode/vsce": "^2.19.0",


### PR DESCRIPTION
Rather than the latest, this matches the other extensions and was when the newer Node version was first adopted by VS Code.