### PR TITLE
Allow .NET Runtime Selection When Creating Http Function

### DIFF
--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -33,7 +33,6 @@ export async function createHttpFunction(context: IActionContext): Promise<void>
         suppressCreateProjectPrompt: true,
         templateId: 'HttpTrigger',
         languageFilter: /Python|C\#|^(Java|Type)Script$/i,
-        functionSettings: { authLevel: 'anonymous' },
-        targetFramework: ['net6.0', 'net7.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
+        functionSettings: { authLevel: 'anonymous' }
     });
 }

--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -33,6 +33,7 @@ export async function createHttpFunction(context: IActionContext): Promise<void>
         suppressCreateProjectPrompt: true,
         templateId: 'HttpTrigger',
         languageFilter: /Python|C\#|^(Java|Type)Script$/i,
-        functionSettings: { authLevel: 'anonymous' }
+        functionSettings: { authLevel: 'anonymous' },
+        targetFramework: ['net8.0']
     });
 }


### PR DESCRIPTION
Resolves GitHub issue: 
GitHub  https://github.com/microsoft/vscode-azurestaticwebapps/issues/761

By removing the `targetFramework` option when creating an Azure Function using the extension, the context will be initialized with a `null` workerRuntime property which will then prompt the user to select which .NET runtime stack to use as the next step.
![image](https://github.com/microsoft/vscode-azurestaticwebapps/assets/30346660/230e8b9d-17d7-4e1f-9364-94d6a92c1719)
