### PR TITLE
Add and Default .Net8.0 to createHttpFunction targetFramework

### DIFF
--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -34,6 +34,6 @@ export async function createHttpFunction(context: IActionContext): Promise<void>
         templateId: 'HttpTrigger',
         languageFilter: /Python|C\#|^(Java|Type)Script$/i,
         functionSettings: { authLevel: 'anonymous' },
-        targetFramework: ['net6.0', 'net7.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
+        targetFramework: ['net6.0', 'net7.0', 'net8.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
     });
 }

--- a/src/commands/createHttpFunction.ts
+++ b/src/commands/createHttpFunction.ts
@@ -34,6 +34,6 @@ export async function createHttpFunction(context: IActionContext): Promise<void>
         templateId: 'HttpTrigger',
         languageFilter: /Python|C\#|^(Java|Type)Script$/i,
         functionSettings: { authLevel: 'anonymous' },
-        targetFramework: ['net6.0', 'net7.0', 'net8.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
+        targetFramework: ['net8.0', 'net7.0', 'net6.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
     });
 }


### PR DESCRIPTION
Adding .NET 8 to the targetFramework as the default for creating HTTP functions since it is now supported in Azure Functions.

Suggested by this comment: https://github.com/microsoft/vscode-azurestaticwebapps/issues/761#issuecomment-1821371282 