### PR TITLE
Adding support for Logic Apps extension. 

### DIFF
--- a/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
+++ b/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
@@ -46,4 +46,9 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext,
 
     // created when the wizard is done executing
     staticWebApp?: StaticSiteARMResource;
+
+    // logic app
+    logicApp?: string;
+
+
 }

--- a/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
+++ b/src/commands/createStaticWebApp/IStaticWebAppWizardContext.ts
@@ -48,7 +48,7 @@ export interface IStaticWebAppWizardContext extends IResourceGroupWizardContext,
     staticWebApp?: StaticSiteARMResource;
 
     // logic app
-    logicApp?: string;
+    logicApp?: {backendResourceId: string, region: string, name: string};
 
 
 }

--- a/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
@@ -18,7 +18,6 @@ export class StaticWebAppCreateStep extends AzureWizardExecuteStep<IStaticWebApp
     public priority: number = 250;
 
     public async execute(context: IStaticWebAppWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
-        context.branchData = {name : "main"};
 
         const octokitClient: Octokit = await createOctokitClient(context);
 
@@ -27,6 +26,20 @@ export class StaticWebAppCreateStep extends AzureWizardExecuteStep<IStaticWebApp
 
         const { data } = await octokitClient.repos.get({ owner, repo });
         context.repoHtmlUrl = data.html_url;
+
+        const { data: branches } = await octokitClient.repos.listBranches({
+            owner,
+            repo
+        });
+
+        const defaultBranch = branches.find(branch => branch.name === 'main');
+
+        if (defaultBranch) {
+            context.branchData = { name: defaultBranch.name };
+
+        } else {
+            context.branchData = {name: branches[0].name };
+        }
 
         const newName: string = nonNullProp(context, 'newStaticWebAppName');
         const branchData = nonNullProp(context, 'branchData');

--- a/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
+++ b/src/commands/createStaticWebApp/StaticWebAppCreateStep.ts
@@ -7,15 +7,27 @@ import { StaticSiteARMResource } from "@azure/arm-appservice";
 import { LocationListStep } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardExecuteStep, nonNullProp, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { AppResource } from "@microsoft/vscode-azext-utils/hostapi";
+import { Octokit } from "@octokit/rest";
 import { Progress } from "vscode";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
+import { createOctokitClient } from "../github/createOctokitClient";
 import { IStaticWebAppWizardContext } from "./IStaticWebAppWizardContext";
 
 export class StaticWebAppCreateStep extends AzureWizardExecuteStep<IStaticWebAppWizardContext> {
     public priority: number = 250;
 
     public async execute(context: IStaticWebAppWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+        context.branchData = {name : "main"};
+
+        const octokitClient: Octokit = await createOctokitClient(context);
+
+        const owner = "alain-zhiyanov";
+        const repo = context.newStaticWebAppName || 'def';
+
+        const { data } = await octokitClient.repos.get({ owner, repo });
+        context.repoHtmlUrl = data.html_url;
+
         const newName: string = nonNullProp(context, 'newStaticWebAppName');
         const branchData = nonNullProp(context, 'branchData');
         const siteEnvelope: StaticSiteARMResource = {

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -50,6 +50,7 @@ function isSubscription(item?: SubscriptionTreeItemBase): item is SubscriptionTr
 
 let isVerifyingWorkspace: boolean = false;
 export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase): Promise<AppResource> {
+    console.log("STARTING STATIC WEB APP LOG");
     if (isVerifyingWorkspace) {
         throw new VerifyingWorkspaceError(context);
     }

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -6,14 +6,12 @@
 // biome-ignore lint/style/useNodejsImportProtocol: <explanation>
 import { promises as fs } from 'fs'; // Import the promises API from fs
 // biome-ignore lint/style/useNodejsImportProtocol: <explanation>
-import { homedir } from 'os';
-
-
 import type { StaticSiteARMResource, WebSiteManagementClient } from '@azure/arm-appservice';
 import { LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, SubscriptionTreeItemBase, VerifyProvidersStep } from '@microsoft/vscode-azext-azureutils';
 import { AzExtFsExtra, AzureWizard, nonNullProp, type AzureWizardExecuteStep, type AzureWizardPromptStep, type ExecuteActivityContext, type IActionContext, type ICreateChildImplContext } from '@microsoft/vscode-azext-utils';
 import type { AppResource } from '@microsoft/vscode-azext-utils/hostapi';
 import type { Octokit } from '@octokit/rest';
+import { homedir } from 'os';
 import { join } from 'path';
 import { ProgressLocation, Uri, window, workspace, type ProgressOptions, type WorkspaceFolder } from 'vscode';
 import { Utils } from 'vscode-uri';
@@ -61,14 +59,14 @@ function isSubscription(item?: SubscriptionTreeItemBase): item is SubscriptionTr
 }
 
 let isVerifyingWorkspace = false;
-export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase, nodes?: SubscriptionTreeItemBase[], ...args: unknown[]): Promise<AppResource> {
+export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase, _nodes?: SubscriptionTreeItemBase[], ...args: unknown[]): Promise<AppResource> {
 
     //logic app paramater was passed in args so flow which inits SWA with LA is called
     if (args.length > 0) {
         type Resource = {backendResourceId: string, region: string, name: string};
         const logicApp = args[0] as unknown as Resource;
         context.logicApp = logicApp;
-        return createStaticWebAppWithLogicApp(context, node, nodes, args);
+        return await createStaticWebAppWithLogicApp(context);
     }
 
     if (isVerifyingWorkspace) {
@@ -198,7 +196,7 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
 
 
 
-export async function createStaticWebAppWithLogicApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase, nodes?: SubscriptionTreeItemBase[], ...args: unknown[]): Promise<AppResource> {
+export async function createStaticWebAppWithLogicApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase): Promise<AppResource> {
     console.log("STARTING STATIC WEB APP LOG");
 
     if (isVerifyingWorkspace) {

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -15,7 +15,6 @@ import { AzExtFsExtra, AzureWizard, nonNullProp, type AzureWizardExecuteStep, ty
 import type { AppResource } from '@microsoft/vscode-azext-utils/hostapi';
 import type { Octokit } from '@octokit/rest';
 import { join } from 'path';
-import * as vscodeExtension from 'vscode';
 import { ProgressLocation, Uri, window, workspace, type ProgressOptions, type WorkspaceFolder } from 'vscode';
 import { Utils } from 'vscode-uri';
 import { StaticWebAppResolver } from '../../StaticWebAppResolver';
@@ -54,7 +53,7 @@ import { tryGetApiLocations } from './tryGetApiLocations';
 function isSubscription(item?: SubscriptionTreeItemBase): item is SubscriptionTreeItemBase {
     try {
         // Accessing item.subscription throws an error for some workspace items
-        // see https://github.com/microsoft/vscode-azurefunctions/issues/3731
+        // see https://github.com/microsoft/vscode-azurefunctions/issues/3731s
         return !!item && !!item.subscription;
     } catch {
         return false;
@@ -62,14 +61,144 @@ function isSubscription(item?: SubscriptionTreeItemBase): item is SubscriptionTr
 }
 
 let isVerifyingWorkspace = false;
-export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase, logicApp?: string): Promise<AppResource> {
-    await vscodeExtension.commands.executeCommand('staticWebApps.createStaticWebApp', undefined, "my-logic-app");
+export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase, nodes?: SubscriptionTreeItemBase[], ...args: unknown[]): Promise<AppResource> {
+
+    //logic app paramater was passed in args so flow which inits SWA with LA is called
+    if (args.length > 0) {
+        type Resource = {backendResourceId: string, region: string, name: string};
+        const logicApp = args[0] as unknown as Resource;
+        context.logicApp = logicApp;
+        return createStaticWebAppWithLogicApp(context, node, nodes, args);
+    }
+
+    if (isVerifyingWorkspace) {
+        throw new VerifyingWorkspaceError(context);
+    }
+    const progressOptions: ProgressOptions = {
+        location: ProgressLocation.Window,
+        title: localize('verifyingWorkspace', 'Verifying workspace...')
+    };
+    isVerifyingWorkspace = true;
+    try {
+        if (!isSubscription(node)) {
+            node = await ext.rgApi.appResourceTree.showTreeItemPicker<SubscriptionTreeItemBase>(SubscriptionTreeItemBase.contextValue, context);
+        }
+        await window.withProgress(progressOptions, async () => {
+            const folder = await tryGetWorkspaceFolder(context);
+            if (folder) {
+                await telemetryUtils.runWithDurationTelemetry(context, 'tryGetFrameworks', async () => {
+                    const detector = new NodeDetector();
+                    const detectorResult = await detector.detect(folder.uri);
+                    // comma separated list of all frameworks detected in this project
+                    context.telemetry.properties.detectedFrameworks = `(${detectorResult?.frameworks.map(fi => fi.framework).join('), (')})` ?? 'N/A';
+                    context.telemetry.properties.rootHasSrcFolder = (await AzExtFsExtra.pathExists(Uri.joinPath(folder.uri, NodeConstants.srcFolderName))).toString();
+                    const subfolderDetectorResults: DetectorResults[] = [];
+                    const subWithSrcFolder: string[] = []
+                    const subfolders = await getSubFolders(context, folder.uri);
+                    for (const subfolder of subfolders) {
+                        const subResult = await detector.detect(subfolder);
+                        if (subResult) {
+                            subfolderDetectorResults.push(subResult);
+                            if (await AzExtFsExtra.pathExists(Uri.joinPath(subfolder, NodeConstants.srcFolderName))) {
+                                subWithSrcFolder.push(Utils.basename(subfolder));
+                            }
+                        }
+                    }
+                    if (subfolderDetectorResults.length > 0) {
+                        // example print: "(Angular,Typescript), (Next.js,React), (Nuxt.js), (React), (Svelte), (Vue.js,Vue.js)"
+                        context.telemetry.properties.detectedFrameworksSub = `(${subfolderDetectorResults.map(dr => dr.frameworks).map(fis => fis.map(fi => fi.framework)).join('), (')})`;
+                        context.telemetry.properties.subFoldersWithSrc = subWithSrcFolder.join(', ');
+                    }
+                });
+                await setGitWorkspaceContexts(context, folder);
+                context.detectedApiLocations = await tryGetApiLocations(context, folder);
+            } else {
+                await showNoWorkspacePrompt(context);
+            }
+        });
+    } finally {
+        isVerifyingWorkspace = false;
+    }
+    const client: WebSiteManagementClient = await createWebSiteClient([context, node.subscription]);
+    const wizardContext: IStaticWebAppWizardContext = {
+        accessToken: await getGitHubAccessToken(),
+        client,
+        ...context,
+        ...node.subscription,
+        ...(await createActivityContext())
+    };
+    const title: string = localize('createStaticApp', 'Create Static Web App');
+    const promptSteps: AzureWizardPromptStep<IStaticWebAppWizardContext & ExecuteActivityContext>[] = [];
+    const executeSteps: AzureWizardExecuteStep<IStaticWebAppWizardContext>[] = [];
+    if (!context.advancedCreation) {
+        wizardContext.sku = SkuListStep.getSkus()[0];
+        executeSteps.push(new ResourceGroupCreateStep());
+    } else {
+        promptSteps.push(new ResourceGroupListStep());
+    }
+    promptSteps.push(new StaticWebAppNameStep(), new SkuListStep());
+    const hasRemote: boolean = !!wizardContext.repoHtmlUrl;
+    // if the local project doesn't have a GitHub remote, we will create it for them
+    if (!hasRemote) {
+        promptSteps.push(new GitHubOrgListStep(), new RepoNameStep(), new RepoPrivacyStep(), new RemoteShortnameStep());
+        executeSteps.push(new RepoCreateStep());
+    }
+    // hard-coding locations available during preview
+    // https://github.com/microsoft/vscode-azurestaticwebapps/issues/18
+    const locations = [
+        'Central US',
+        'East US 2',
+        'East Asia',
+        'West Europe',
+        'West US 2'
+    ];
+    const webProvider: string = 'Microsoft.Web';
+    LocationListStep.setLocationSubset(wizardContext, Promise.resolve(locations), webProvider);
+    LocationListStep.addStep(wizardContext, promptSteps, {
+        placeHolder: localize('selectLocation', 'Select a region for Azure Functions API and staging environments'),
+        noPicksMessage: localize('noRegions', 'No available regions.')
+    });
+    promptSteps.push(new BuildPresetListStep(), new AppLocationStep(), new ApiLocationStep(), new OutputLocationStep());
+    executeSteps.push(new VerifyProvidersStep([webProvider]));
+    executeSteps.push(new StaticWebAppCreateStep());
+    const wizard: AzureWizard<IStaticWebAppWizardContext> = new AzureWizard(wizardContext, {
+        title,
+        promptSteps,
+        executeSteps,
+        showLoadingPrompt: true
+    });
+    wizardContext.telemetry.properties.gotRemote = String(hasRemote);
+    wizardContext.uri = wizardContext.uri || getSingleRootFsPath();
+    wizardContext.telemetry.properties.numberOfWorkspaces = !workspace.workspaceFolders ? String(0) : String(workspace.workspaceFolders.length);
+    await wizard.prompt();
+    wizardContext.activityTitle = localize('createStaticApp', 'Create Static Web App "{0}"', nonNullProp(wizardContext, 'newStaticWebAppName'));
+    if (!context.advancedCreation) {
+        wizardContext.newResourceGroupName = await wizardContext.relatedNameTask;
+    }
+    await wizard.execute();
+    await ext.rgApi.appResourceTree.refresh(context);
+    const swa: StaticSiteARMResource = nonNullProp(wizardContext, 'staticWebApp');
+    await gitPull(nonNullProp(wizardContext, 'repo'));
+    const appResource: AppResource = {
+        id: nonNullProp(swa, 'id'),
+        name: nonNullProp(swa, 'name'),
+        type: nonNullProp(swa, 'type'),
+        ...swa
+    };
+    const resolver = new StaticWebAppResolver();
+    const resolvedSwa = await resolver.resolveResource(node.subscription, appResource);
+    if (resolvedSwa) {
+        await showSwaCreated(resolvedSwa);
+    }
+    return appResource;
+
+}
 
 
 
 
 
-
+export async function createStaticWebAppWithLogicApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase, nodes?: SubscriptionTreeItemBase[], ...args: unknown[]): Promise<AppResource> {
     console.log("STARTING STATIC WEB APP LOG");
 
     if (isVerifyingWorkspace) {
@@ -291,7 +420,6 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
     }
 
     return appResource;
-
 }
 
 export async function createStaticWebAppAdvanced(context: IActionContext, node?: SubscriptionTreeItemBase): Promise<AppResource> {
@@ -301,6 +429,8 @@ export async function createStaticWebAppAdvanced(context: IActionContext, node?:
 function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+
 
 
 

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -51,7 +51,7 @@ import { tryGetApiLocations } from './tryGetApiLocations';
 function isSubscription(item?: SubscriptionTreeItemBase): item is SubscriptionTreeItemBase {
     try {
         // Accessing item.subscription throws an error for some workspace items
-        // see https://github.com/microsoft/vscode-azurefunctions/issues/3731s
+        // see https://github.com/microsoft/vscode-azurefunctions/issues/3731
         return !!item && !!item.subscription;
     } catch {
         return false;

--- a/src/commands/createStaticWebApp/createStaticWebApp.ts
+++ b/src/commands/createStaticWebApp/createStaticWebApp.ts
@@ -3,14 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// biome-ignore lint/style/useNodejsImportProtocol: <explanation>
+import { promises as fs } from 'fs'; // Import the promises API from fs
+// biome-ignore lint/style/useNodejsImportProtocol: <explanation>
+import { homedir } from 'os';
+
+
 import type { StaticSiteARMResource, WebSiteManagementClient } from '@azure/arm-appservice';
 import { LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, SubscriptionTreeItemBase, VerifyProvidersStep } from '@microsoft/vscode-azext-azureutils';
 import { AzExtFsExtra, AzureWizard, nonNullProp, type AzureWizardExecuteStep, type AzureWizardPromptStep, type ExecuteActivityContext, type IActionContext, type ICreateChildImplContext } from '@microsoft/vscode-azext-utils';
 import type { AppResource } from '@microsoft/vscode-azext-utils/hostapi';
 import type { Octokit } from '@octokit/rest';
-import { promises as fs } from 'node:fs'; // Import the promises API from fs
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join } from 'path';
+import * as vscodeExtension from 'vscode';
 import { ProgressLocation, Uri, window, workspace, type ProgressOptions, type WorkspaceFolder } from 'vscode';
 import { Utils } from 'vscode-uri';
 import { StaticWebAppResolver } from '../../StaticWebAppResolver';
@@ -56,8 +61,15 @@ function isSubscription(item?: SubscriptionTreeItemBase): item is SubscriptionTr
     }
 }
 
-let isVerifyingWorkspace =  false;
-export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase): Promise<AppResource> {
+let isVerifyingWorkspace = false;
+export async function createStaticWebApp(context: IActionContext & Partial<ICreateChildImplContext> & Partial<IStaticWebAppWizardContext>, node?: SubscriptionTreeItemBase, logicApp?: string): Promise<AppResource> {
+    await vscodeExtension.commands.executeCommand('staticWebApps.createStaticWebApp', undefined, "my-logic-app");
+
+
+
+
+
+
     console.log("STARTING STATIC WEB APP LOG");
 
     if (isVerifyingWorkspace) {
@@ -96,7 +108,8 @@ export async function createStaticWebApp(context: IActionContext & Partial<ICrea
 
 
     if (!context.advancedCreation) {
-        wizardContext.sku = SkuListStep.getSkus()[0];
+        //[1] gets standard and not free
+        wizardContext.sku = SkuListStep.getSkus()[1];
         executeSteps.push(new ResourceGroupCreateStep());
     } else {
         promptSteps.push(new ResourceGroupListStep());
@@ -287,7 +300,7 @@ export async function createStaticWebAppAdvanced(context: IActionContext, node?:
 
 function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
-  }
+}
 
 
 

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -25,7 +25,6 @@ import { openGitHubLog } from './github/jobLogs/openGitHubLog';
 import { openGitHubRepo } from './github/openGitHubRepo';
 import { showActions } from './github/showActions';
 import { openInPortal } from './openInPortal';
-import { openYAMLConfigFile } from './openYAMLConfigFile';
 import { viewProperties } from './viewProperties';
 
 export function registerCommands(): void {
@@ -51,7 +50,7 @@ export function registerCommands(): void {
     registerCommandWithTreeNodeUnwrapping('staticWebApps.toggleAppSettingVisibility', async (context: IActionContext, node?: AppSettingTreeItem) => { await nonNullValue(node).toggleValueVisibility(context); }, 250);
     registerCommand('staticWebApps.showDocumentation', async (_context: IActionContext) => { await openUrl('https://aka.ms/AA92xai'); });
     registerCommand('staticWebApps.showFunctionsDocumentation', async (_context: IActionContext) => { await openUrl('https://aka.ms/AAacf3z'); });
-    registerCommandWithTreeNodeUnwrapping('staticWebApps.openYAMLConfigFile', openYAMLConfigFile);
+    //registerCommandWithTreeNodeUnwrapping('staticWebApps.openYAMLConfigFile', openYAMLConfigFile);
     registerCommand('staticWebApps.createSwaConfigFile', createSwaConfigFile);
     registerCommandWithTreeNodeUnwrapping('staticWebApps.openGitHubLog', openGitHubLog);
     registerCommand('staticWebApps.installOrUpdateStaticWebAppsCli', installOrUpdateSwaCli);


### PR DESCRIPTION
'Create Static Web App' command now supports being called from Logic Apps VSCode extension. The command will now initialize and deploy a Static Web App which is in the same directory and a linked backend for the user's Logic App.

@mkarmark @annikel @joslinmicrosoft 